### PR TITLE
Implement chunk assembly + prompt rendering (#8)

### DIFF
--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -1,0 +1,453 @@
+"""Chunk assembly with drift-priority scheduling.
+
+Reworked from v2's next_chunk() for v3: 4 living docs, stable IDs,
+FULL/STUB forms, and all 4 drift threshold types.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from engram.config import resolve_doc_paths
+from engram.fold.ids import IDAllocator, estimate_new_entities
+from engram.fold.prompt import render_agent_prompt, render_chunk_input, render_triage_input
+from engram.parse import extract_id, is_stub, parse_sections
+
+# Regex for ISO dates (YYYY-MM-DD) in text
+_DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
+
+
+@dataclass
+class DriftReport:
+    """Results from scanning living docs for drift conditions."""
+
+    orphaned_concepts: list[dict] = field(default_factory=list)
+    contested_claims: list[dict] = field(default_factory=list)
+    stale_unverified: list[dict] = field(default_factory=list)
+    workflow_repetitions: list[dict] = field(default_factory=list)
+
+    def triggered(self, thresholds: dict) -> str | None:
+        """Return the highest-priority drift type that exceeds its threshold.
+
+        Priority order: orphans > contested > stale_unverified > workflow.
+        Returns None if no threshold is exceeded.
+        """
+        if len(self.orphaned_concepts) > thresholds.get("orphan_triage", 50):
+            return "orphan_triage"
+        if self.contested_claims:
+            return "contested_review"
+        if self.stale_unverified:
+            return "stale_unverified"
+        if len(self.workflow_repetitions) > thresholds.get("workflow_repetition", 3):
+            return "workflow_synthesis"
+        return None
+
+
+@dataclass
+class ChunkResult:
+    """Output from next_chunk() for CLI reporting."""
+
+    chunk_id: int
+    input_path: Path
+    prompt_path: Path
+    chunk_type: str  # "fold" | "orphan_triage" | "contested_review" | ...
+    items_count: int
+    chunk_chars: int
+    budget: int
+    living_docs_chars: int
+    remaining_queue: int
+    date_range: str | None = None
+    drift_entry_count: int = 0
+    pre_assigned_ids: dict[str, list[str]] = field(default_factory=dict)
+
+
+# ------------------------------------------------------------------
+# Drift detection
+# ------------------------------------------------------------------
+
+
+def _extract_code_paths(section_text: str) -> list[str]:
+    """Extract file paths from a Code: field in a concept section."""
+    paths: list[str] = []
+    for line in section_text.split("\n"):
+        stripped = line.strip()
+        if not stripped.startswith("- **Code:**") and not stripped.startswith("**Code:**"):
+            continue
+        # Everything after "Code:" is the value
+        _, _, val = stripped.partition(":**")
+        val = val.strip()
+        for p in val.split(","):
+            p = p.strip().strip("`").strip()
+            if p:
+                paths.append(p)
+    return paths
+
+
+def _find_orphaned_concepts(concepts_path: Path, project_root: Path) -> list[dict]:
+    """Find ACTIVE concepts whose referenced source files are all missing."""
+    if not concepts_path.exists():
+        return []
+    sections = parse_sections(concepts_path.read_text())
+    orphans: list[dict] = []
+    for sec in sections:
+        # ACTIVE is not in parse.STATUS_RE, so sec["status"] is None for
+        # ACTIVE entries. Check heading directly for "(ACTIVE".
+        if "(ACTIVE" not in sec["heading"].upper():
+            continue
+        if is_stub(sec["heading"]):
+            continue
+        code_paths = _extract_code_paths(sec["text"])
+        if not code_paths:
+            continue
+        if all(not (project_root / p).exists() for p in code_paths):
+            orphans.append({
+                "name": sec["heading"].lstrip("#").strip(),
+                "id": extract_id(sec["heading"]),
+                "paths": code_paths,
+            })
+    return orphans
+
+
+def _extract_latest_date(text: str) -> datetime | None:
+    """Extract the most recent YYYY-MM-DD date from text."""
+    matches = _DATE_RE.findall(text)
+    if not matches:
+        return None
+    parsed = []
+    for d in matches:
+        try:
+            parsed.append(datetime.strptime(d, "%Y-%m-%d").replace(tzinfo=timezone.utc))
+        except ValueError:
+            continue
+    return max(parsed) if parsed else None
+
+
+def _find_claims_by_status(
+    epistemic_path: Path, status: str, days_threshold: int,
+) -> list[dict]:
+    """Find epistemic entries with given status older than days_threshold."""
+    if not epistemic_path.exists():
+        return []
+    sections = parse_sections(epistemic_path.read_text())
+    now = datetime.now(timezone.utc)
+    results: list[dict] = []
+    for sec in sections:
+        if sec["status"] != status:
+            continue
+        if is_stub(sec["heading"]):
+            continue
+        latest = _extract_latest_date(sec["text"])
+        if latest is None:
+            continue
+        age_days = (now - latest).days
+        if age_days > days_threshold:
+            results.append({
+                "name": sec["heading"].lstrip("#").strip(),
+                "id": extract_id(sec["heading"]),
+                "days_old": age_days,
+                "last_date": latest.strftime("%Y-%m-%d"),
+            })
+    return results
+
+
+def _find_workflow_repetitions(workflows_path: Path) -> list[dict]:
+    """Find CURRENT workflow entries as candidates for synthesis.
+
+    Returns all CURRENT (non-STUB) workflows. The caller compares
+    the count against the workflow_repetition threshold.
+    """
+    if not workflows_path.exists():
+        return []
+    sections = parse_sections(workflows_path.read_text())
+    results: list[dict] = []
+    for sec in sections:
+        if sec["status"] != "current":
+            continue
+        if is_stub(sec["heading"]):
+            continue
+        results.append({
+            "name": sec["heading"].lstrip("#").strip(),
+            "id": extract_id(sec["heading"]),
+        })
+    return results
+
+
+def scan_drift(config: dict, project_root: Path) -> DriftReport:
+    """Scan all living docs for drift conditions."""
+    paths = resolve_doc_paths(config, project_root)
+    thresholds = config.get("thresholds", {})
+
+    return DriftReport(
+        orphaned_concepts=_find_orphaned_concepts(paths["concepts"], project_root),
+        contested_claims=_find_claims_by_status(
+            paths["epistemic"], "contested",
+            thresholds.get("contested_review_days", 14),
+        ),
+        stale_unverified=_find_claims_by_status(
+            paths["epistemic"], "unverified",
+            thresholds.get("stale_unverified_days", 30),
+        ),
+        workflow_repetitions=_find_workflow_repetitions(paths["workflows"]),
+    )
+
+
+# ------------------------------------------------------------------
+# Budget computation
+# ------------------------------------------------------------------
+
+
+def compute_budget(config: dict, doc_paths: dict[str, Path]) -> tuple[int, int]:
+    """Compute available char budget for chunk content.
+
+    Returns (budget, living_docs_chars).
+    """
+    budget_cfg = config.get("budget", {})
+    context_limit = budget_cfg.get("context_limit_chars", 600_000)
+    overhead = budget_cfg.get("instructions_overhead", 10_000)
+    max_chunk = budget_cfg.get("max_chunk_chars", 200_000)
+
+    living_doc_keys = ["timeline", "concepts", "epistemic", "workflows"]
+    living_docs_chars = 0
+    for key in living_doc_keys:
+        p = doc_paths.get(key)
+        if p and p.exists():
+            living_docs_chars += len(p.read_text())
+
+    remaining = context_limit - living_docs_chars - overhead
+    return min(remaining, max_chunk), living_docs_chars
+
+
+# ------------------------------------------------------------------
+# Item rendering
+# ------------------------------------------------------------------
+
+
+def _render_item_content(item: dict[str, Any], project_root: Path) -> str:
+    """Render a single queue item as markdown for the chunk input."""
+    tag = "REVISIT" if item["pass"] == "revisit" else "INITIAL"
+    item_path = project_root / item["path"]
+
+    if item["type"] == "prompts":
+        n = item.get("prompt_count", "?")
+        header = f"## [USER PROMPTS] Session ({n} prompts)\n"
+        header += f"**Date:** {item['date'][:10]}\n\n"
+    elif item["type"] == "issue":
+        header = f"## [{tag}] Issue #{item['issue_number']}: {item['issue_title']}\n"
+        header += f"**Created:** {item['date'][:10]}\n\n"
+    else:
+        header = f"## [{tag}] Doc: {item['path']}\n"
+        header += f"**Created:** {item['date'][:10]}"
+        if tag == "REVISIT":
+            header += f" | **Modified:** {item['date'][:10]}"
+            header += f" | **First seen:** {item.get('first_seen_date', '?')[:10]}"
+            header += (
+                "\nThis doc was updated since first processed. "
+                "Check existing entries and update based on what changed."
+            )
+        header += "\n\n"
+
+    try:
+        if item["type"] == "issue":
+            from engram.fold.sources import render_issue_markdown
+            issue_data = json.loads(item_path.read_text())
+            content = render_issue_markdown(issue_data)
+        else:
+            content = item_path.read_text(errors="ignore")
+    except FileNotFoundError:
+        content = f"[FILE NOT FOUND: {item_path}]\n"
+
+    return header + content + "\n\n---\n\n"
+
+
+# ------------------------------------------------------------------
+# Main entry point
+# ------------------------------------------------------------------
+
+
+def next_chunk(config: dict, project_root: Path) -> ChunkResult:
+    """Build the next chunk's input.md and prompt.txt.
+
+    Returns a ChunkResult with paths and metadata for CLI reporting.
+
+    Raises:
+        FileNotFoundError: If queue.jsonl doesn't exist.
+        ValueError: If queue is empty.
+    """
+    engram_dir = project_root / ".engram"
+    chunks_dir = engram_dir / "chunks"
+    chunks_dir.mkdir(parents=True, exist_ok=True)
+    queue_file = engram_dir / "queue.jsonl"
+    manifest_file = engram_dir / "chunks_manifest.yaml"
+
+    if not queue_file.exists():
+        raise FileNotFoundError("No queue found. Run 'build-queue' first.")
+
+    with open(queue_file) as fh:
+        queue = [json.loads(line) for line in fh if line.strip()]
+
+    if not queue:
+        raise ValueError("Queue is empty. All chunks have been produced.")
+
+    # Determine chunk ID from existing chunks
+    existing = list(chunks_dir.glob("chunk_*_input.md"))
+    chunk_id = len(existing) + 1
+
+    doc_paths = resolve_doc_paths(config, project_root)
+    budget, living_docs_chars = compute_budget(config, doc_paths)
+
+    # Check drift priorities
+    drift = scan_drift(config, project_root)
+    thresholds = config.get("thresholds", {})
+    drift_type = drift.triggered(thresholds)
+
+    if drift_type:
+        # Drift triage chunk — queue is NOT consumed
+        with open(queue_file, "w") as fh:
+            for entry in queue:
+                fh.write(json.dumps(entry) + "\n")
+
+        input_content = render_triage_input(
+            drift_type=drift_type,
+            drift_report=drift,
+            chunk_id=chunk_id,
+            doc_paths=doc_paths,
+        )
+
+        input_path = chunks_dir / f"chunk_{chunk_id:03d}_input.md"
+        input_path.write_text(input_content)
+
+        prompt_content = render_agent_prompt(
+            chunk_id=chunk_id,
+            date_range=drift_type,
+            input_path=input_path,
+            doc_paths=doc_paths,
+        )
+        prompt_path = chunks_dir / f"chunk_{chunk_id:03d}_prompt.txt"
+        prompt_path.write_text(prompt_content)
+
+        # Count drift entries for reporting
+        drift_counts = {
+            "orphan_triage": len(drift.orphaned_concepts),
+            "contested_review": len(drift.contested_claims),
+            "stale_unverified": len(drift.stale_unverified),
+            "workflow_synthesis": len(drift.workflow_repetitions),
+        }
+
+        with open(manifest_file, "a") as fh:
+            fh.write(
+                f"- id: {chunk_id}\n"
+                f"  type: {drift_type}\n"
+                f"  entries: {drift_counts.get(drift_type, 0)}\n"
+                f"  input_file: {input_path.name}\n"
+            )
+
+        return ChunkResult(
+            chunk_id=chunk_id,
+            input_path=input_path,
+            prompt_path=prompt_path,
+            chunk_type=drift_type,
+            items_count=0,
+            chunk_chars=len(input_content),
+            budget=budget,
+            living_docs_chars=living_docs_chars,
+            remaining_queue=len(queue),
+            drift_entry_count=drift_counts.get(drift_type, 0),
+        )
+
+    # Normal chunk — fill from queue up to budget
+    chunk_items: list[dict] = []
+    chunk_chars = 0
+    while queue and (chunk_chars + queue[0]["chars"]) <= budget:
+        item = queue.pop(0)
+        chunk_items.append(item)
+        chunk_chars += item["chars"]
+
+    if not chunk_items and queue:
+        # Single oversized item — take it anyway
+        item = queue.pop(0)
+        chunk_items.append(item)
+        chunk_chars = item["chars"]
+
+    # Pre-assign IDs
+    estimates = estimate_new_entities(chunk_items)
+    db_path = engram_dir / "engram.db"
+    with IDAllocator(db_path) as allocator:
+        pre_assigned = allocator.pre_assign_for_chunk(
+            new_concepts=estimates["C"],
+            new_epistemic=estimates["E"],
+            new_workflows=estimates["W"],
+        )
+
+    date_range = f"{chunk_items[0]['date'][:10]} to {chunk_items[-1]['date'][:10]}"
+
+    # Render item contents
+    items_content = ""
+    for item in chunk_items:
+        items_content += _render_item_content(item, project_root)
+
+    # Include orphan advisory (below threshold, informational)
+    orphan_advisory = ""
+    if drift.orphaned_concepts:
+        orphan_advisory = (
+            "## [ORPHANED CONCEPTS] Active concepts with missing source files\n\n"
+        )
+        for o in drift.orphaned_concepts:
+            orphan_advisory += f"- **{o['name']}**: {', '.join(o['paths'])}\n"
+        orphan_advisory += (
+            f"\n({len(drift.orphaned_concepts)} orphaned concepts found)\n\n---\n\n"
+        )
+
+    input_content = render_chunk_input(
+        chunk_id=chunk_id,
+        date_range=date_range,
+        items_content=items_content,
+        orphan_advisory=orphan_advisory,
+        pre_assigned_ids=pre_assigned,
+        doc_paths=doc_paths,
+    )
+
+    input_path = chunks_dir / f"chunk_{chunk_id:03d}_input.md"
+    input_path.write_text(input_content)
+
+    prompt_content = render_agent_prompt(
+        chunk_id=chunk_id,
+        date_range=date_range,
+        input_path=input_path,
+        doc_paths=doc_paths,
+    )
+    prompt_path = chunks_dir / f"chunk_{chunk_id:03d}_prompt.txt"
+    prompt_path.write_text(prompt_content)
+
+    # Write remaining queue
+    with open(queue_file, "w") as fh:
+        for entry in queue:
+            fh.write(json.dumps(entry) + "\n")
+
+    # Append manifest
+    with open(manifest_file, "a") as fh:
+        fh.write(
+            f"- id: {chunk_id}\n"
+            f'  date_range: "{date_range}"\n'
+            f"  items: {len(chunk_items)}\n"
+            f"  chars: {chunk_chars}\n"
+            f"  input_file: {input_path.name}\n"
+        )
+
+    return ChunkResult(
+        chunk_id=chunk_id,
+        input_path=input_path,
+        prompt_path=prompt_path,
+        chunk_type="fold",
+        items_count=len(chunk_items),
+        chunk_chars=chunk_chars,
+        budget=budget,
+        living_docs_chars=living_docs_chars,
+        remaining_queue=len(queue),
+        date_range=date_range,
+        pre_assigned_ids=pre_assigned,
+    )

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -1,0 +1,111 @@
+# Instructions
+
+You are updating 4 knowledge documents based on new project artifacts.
+
+Read the new content below, then edit the 4 living docs using your file editing tools:
+
+- **{{ doc_paths.timeline }}** — Chronological narrative. Write in phases/events.
+- **{{ doc_paths.concepts }}** — Concept registry keyed by stable ID (C###).
+- **{{ doc_paths.epistemic }}** — Epistemic state keyed by stable ID (E###).
+- **{{ doc_paths.workflows }}** — Workflow registry keyed by stable ID (W###).
+
+## Stable IDs
+
+Every entry uses a permanent stable ID: C### for concepts, E### for claims, W### for workflows.
+IDs survive renames, refactoring, and evolution. Never reuse an ID.
+
+{% if pre_assigned_ids %}
+### Pre-assigned IDs for this chunk
+
+Use ONLY these IDs for new entries. Do NOT invent your own.
+
+{% for cat, ids in pre_assigned_ids.items() %}
+- {{ cat }}: {{ ids | join(', ') }}
+{% endfor %}
+{% endif %}
+
+## Entry Formats
+
+### FULL form (ACTIVE / CURRENT / believed / contested / unverified)
+
+All required fields must be present.
+
+**Concept registry:**
+
+    ## C{NNN}: {name} (ACTIVE[ — {MODIFIER}])
+    - **Code:** relevant source files
+    - **Issues:** issue numbers
+    - **Rationale:** documented | empty | questioned
+    - **Debt:** known incompleteness
+    - **Relationships:** connections (C###, E###, W###)
+
+**Epistemic state:**
+
+    ## E{NNN}: {name} (believed|contested|unverified)
+    **Current position:** 1-2 sentences.
+    **History:**
+    - #issue: "claim" → status
+    **Agent guidance:** 1 sentence only.
+
+**Workflow registry:**
+
+    ## W{NNN}: {name} (CURRENT[ — {MODIFIER}])
+    - **Context:** when/why this workflow applies
+    - **Trigger:** what initiates it (or **Current method:** how it's done)
+
+### STUB form (DEAD / EVOLVED / SUPERSEDED / MERGED / refuted)
+
+One-liner with graveyard pointer. No field requirements.
+
+    ## C042: proximity_pruning (DEAD) → {{ doc_paths.concept_graveyard | basename }}#C042
+    ## E007: phantom_wr (refuted) → {{ doc_paths.epistemic_graveyard | basename }}#E007
+    ## W003: manual_deploy (SUPERSEDED) → W008
+
+## Graveyard Moves
+
+When a concept flips DEAD or EVOLVED, or a claim flips refuted:
+1. **Append** the full entry to the graveyard file:
+   - Concepts → {{ doc_paths.concept_graveyard }}
+   - Claims → {{ doc_paths.epistemic_graveyard }}
+2. **Replace** the living doc entry with a STUB (one-liner + pointer).
+
+Graveyard files are append-only. Never edit existing graveyard entries.
+
+## How to Handle Each Item Type
+
+**INITIAL items** (first time seeing this artifact):
+- Extract concepts, claims, timeline events, and workflow patterns
+- Add new entries using pre-assigned IDs
+- If content references things not yet in the living docs, add provisionally
+
+**REVISIT items** (updated since first processed):
+- Check what exists from the initial pass
+- Update entries based on changes
+- Pay attention to epistemic shifts — revisits often mean claims were tested
+
+**USER PROMPTS** (project owner's direct inputs):
+- Most information-dense items. A single sentence often encodes a major decision.
+- They reveal: intent, corrections, decisions, priorities, dead ends, rationale
+- Read as conversation threads — sequence within a session tells a story
+- When prompts contradict docs/issues, the prompt is authoritative
+
+## Style
+
+- **Be succinct.** High information density. No filler.
+- Timeline: short factual entries. What happened, why, what resulted.
+- Concept registry: structured fields only. 5 lines ideal, 10 max.
+- Epistemic state: 1-2 sentence position. History as bullet list. 1-sentence agent guidance.
+- Workflow registry: structured fields only. Context + trigger/method.
+- DEAD/refuted entries: 1-2 sentences max. Key lesson + replacement.
+- **Budget matters.** Every line stays in context for future chunks. Be ruthless about cutting words.
+
+## Important
+
+- Use Edit for surgical updates. Do NOT reproduce entire documents.
+- Only edit sections affected by new content.
+- Capture cross-concept relationships using stable IDs (C###, E###, W###).
+- Architect review comments on merged PRs = debt.
+- When two artifacts make contradictory claims, that's an epistemic entry.
+- Do NOT add entries about the fold process itself.
+- When a concept's source files are deleted, mark it DEAD.
+- When an ORPHANED CONCEPTS section is present, triage each one.

--- a/engram/templates/seed_prompt.md
+++ b/engram/templates/seed_prompt.md
@@ -1,0 +1,49 @@
+# Bootstrap Seed Instructions
+
+You are initializing 4 knowledge documents for a new project.
+
+Read all the content below, then populate the living docs with initial entries:
+
+- **{{ doc_paths.timeline }}** — Start the chronological narrative from the earliest events.
+- **{{ doc_paths.concepts }}** — Register all code concepts found with stable IDs (C001, C002, ...).
+- **{{ doc_paths.epistemic }}** — Capture all claims and beliefs with stable IDs (E001, E002, ...).
+- **{{ doc_paths.workflows }}** — Document all process patterns with stable IDs (W001, W002, ...).
+
+{% if pre_assigned_ids %}
+### Pre-assigned IDs
+
+Use ONLY these IDs for new entries. Do NOT invent your own.
+
+{% for cat, ids in pre_assigned_ids.items() %}
+- {{ cat }}: {{ ids | join(', ') }}
+{% endfor %}
+{% endif %}
+
+## Entry Formats
+
+**Concepts (FULL form):**
+
+    ## C{NNN}: {name} (ACTIVE)
+    - **Code:** source files
+    - **Issues:** related issue numbers
+    - **Relationships:** connections (C###, E###, W###)
+
+**Epistemic claims (FULL form):**
+
+    ## E{NNN}: {name} (believed|unverified)
+    **Current position:** 1-2 sentences.
+    **History:**
+    - source: "claim" → status
+
+**Workflows (FULL form):**
+
+    ## W{NNN}: {name} (CURRENT)
+    - **Context:** when/why
+    - **Trigger:** what initiates it
+
+## Style
+
+- Be succinct. 5 lines per entry ideal, 10 max.
+- Focus on what exists now, not historical evolution (that comes in subsequent chunks).
+- Capture relationships between concepts using stable IDs.
+- Mark anything uncertain as (unverified) — subsequent chunks will provide evidence.

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -1,0 +1,101 @@
+# Instructions
+
+You are updating 4 knowledge documents to resolve drift.
+
+Living docs:
+- **{{ doc_paths.timeline }}** — Chronological narrative.
+- **{{ doc_paths.concepts }}** — Concept registry (C###).
+- **{{ doc_paths.epistemic }}** — Epistemic state (E###).
+- **{{ doc_paths.workflows }}** — Workflow registry (W###).
+
+Graveyard files (append-only):
+- {{ doc_paths.concept_graveyard }}
+- {{ doc_paths.epistemic_graveyard }}
+
+---
+
+{% if drift_type == "orphan_triage" %}
+# Orphan Triage Round (Chunk {{ chunk_id }})
+
+This is a dedicated cleanup round. No new content to process.
+Your ONLY job is to triage the orphaned concepts below.
+
+## [ORPHANED CONCEPTS] Active concepts with missing source files
+
+The following concepts are marked ACTIVE but ALL their referenced source files
+no longer exist. All source trees are in the same repo — "different source tree"
+is never a valid reason to skip triage. For each one:
+
+- Mark **DEAD** if the concept was abandoned/replaced.
+  Use 1-2 sentences: what replaced it + key lesson.
+  Move the full entry to {{ doc_paths.concept_graveyard }}, replace with STUB.
+- Mark **EVOLVED → new_name** if it was renamed/restructured.
+  Update the Code: field to point to the new location.
+  (Common renames: .ts→.tsx, ground_truth_annotator/→replay_server/)
+- Leave ACTIVE only if the files are genuinely expected to be created later.
+
+{% for o in entries %}
+- **{{ o.name }}**{% if o.id %} ({{ o.id }}){% endif %}: {{ o.paths | join(', ') }}
+{% endfor %}
+
+({{ entry_count }} orphaned concepts to resolve)
+
+**Goal: get orphan count to 0.** Every entry must be resolved.
+{% elif drift_type == "contested_review" %}
+# Contested Claims Review (Chunk {{ chunk_id }})
+
+This is a dedicated review round for long-standing contested claims.
+These claims have been contested for longer than the review threshold.
+
+For each claim below:
+- **Resolve** if evidence now supports one position. Update status to believed or refuted.
+- **Escalate** if resolution requires data not in the living docs. Add Agent guidance.
+- **Keep contested** only if genuinely unresolved with active investigation.
+
+{% for e in entries %}
+- **{{ e.name }}**{% if e.id %} ({{ e.id }}){% endif %}: {{ e.days_old }} days unresolved (since {{ e.last_date }})
+{% endfor %}
+
+({{ entry_count }} contested claims to review)
+{% elif drift_type == "stale_unverified" %}
+# Stale Unverified Claims Review (Chunk {{ chunk_id }})
+
+This is a dedicated review round for stale unverified claims.
+These claims have remained unverified beyond the staleness threshold.
+
+For each claim below:
+- **Verify** if evidence now exists. Update status to believed with evidence.
+- **Refute** if evidence contradicts the claim. Move to graveyard.
+- **Flag** if verification requires external action. Add Agent guidance with specific steps.
+
+{% for e in entries %}
+- **{{ e.name }}**{% if e.id %} ({{ e.id }}){% endif %}: {{ e.days_old }} days unverified (since {{ e.last_date }})
+{% endfor %}
+
+({{ entry_count }} stale unverified claims to review)
+{% elif drift_type == "workflow_synthesis" %}
+# Workflow Synthesis Round (Chunk {{ chunk_id }})
+
+This is a dedicated round to consolidate repeated workflow patterns.
+The following CURRENT workflows may overlap or duplicate each other.
+
+For each cluster of related workflows:
+- **Merge** if they describe the same process. Mark extras as MERGED → W{target}.
+- **Distinguish** if they are genuinely different. Clarify Context: fields.
+- **Supersede** if one replaces another. Mark old as SUPERSEDED → W{new}.
+
+{% for w in entries %}
+- **{{ w.name }}**{% if w.id %} ({{ w.id }}){% endif %}
+{% endfor %}
+
+({{ entry_count }} workflow entries to review for synthesis)
+{% endif %}
+
+---
+
+## Style
+
+- Use Edit for surgical updates. Do NOT reproduce entire documents.
+- Be succinct. DEAD/refuted entries: 1-2 sentences max.
+- When moving entries to graveyard, append the full content there, then replace
+  the living doc entry with a STUB (heading + arrow pointer only).

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,644 @@
+"""Tests for chunk assembly and drift-priority scheduling."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from engram.fold.chunker import (
+    ChunkResult,
+    DriftReport,
+    _extract_code_paths,
+    _extract_latest_date,
+    _find_claims_by_status,
+    _find_orphaned_concepts,
+    _find_workflow_repetitions,
+    _render_item_content,
+    compute_budget,
+    next_chunk,
+    scan_drift,
+)
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def project(tmp_path):
+    """Set up a minimal engram project with config and living docs."""
+    engram_dir = tmp_path / ".engram"
+    engram_dir.mkdir()
+
+    # Write config
+    config_yaml = """\
+living_docs:
+  timeline: docs/decisions/timeline.md
+  concepts: docs/decisions/concept_registry.md
+  epistemic: docs/decisions/epistemic_state.md
+  workflows: docs/decisions/workflow_registry.md
+graveyard:
+  concepts: docs/decisions/concept_graveyard.md
+  epistemic: docs/decisions/epistemic_graveyard.md
+thresholds:
+  orphan_triage: 3
+  contested_review_days: 14
+  stale_unverified_days: 30
+  workflow_repetition: 3
+budget:
+  context_limit_chars: 600000
+  instructions_overhead: 10000
+  max_chunk_chars: 200000
+"""
+    (engram_dir / "config.yaml").write_text(config_yaml)
+
+    # Create living doc directories
+    docs_dir = tmp_path / "docs" / "decisions"
+    docs_dir.mkdir(parents=True)
+
+    # Create empty living docs
+    (docs_dir / "timeline.md").write_text("# Timeline\n")
+    (docs_dir / "concept_registry.md").write_text("# Concept Registry\n")
+    (docs_dir / "epistemic_state.md").write_text("# Epistemic State\n")
+    (docs_dir / "workflow_registry.md").write_text("# Workflow Registry\n")
+    (docs_dir / "concept_graveyard.md").write_text("# Concept Graveyard\n")
+    (docs_dir / "epistemic_graveyard.md").write_text("# Epistemic Graveyard\n")
+
+    return tmp_path
+
+
+@pytest.fixture()
+def config(project):
+    """Load config from the project fixture."""
+    from engram.config import load_config
+    return load_config(project)
+
+
+def _write_queue(project, items):
+    """Write queue.jsonl to .engram/."""
+    queue_file = project / ".engram" / "queue.jsonl"
+    with open(queue_file, "w") as fh:
+        for item in items:
+            fh.write(json.dumps(item) + "\n")
+
+
+def _make_doc_item(path="docs/working/spec.md", chars=500, date="2025-01-15T00:00:00"):
+    """Create a minimal doc queue entry."""
+    return {
+        "date": date,
+        "type": "doc",
+        "path": path,
+        "chars": chars,
+        "pass": "initial",
+    }
+
+
+# ------------------------------------------------------------------
+# DriftReport.triggered
+# ------------------------------------------------------------------
+
+
+class TestDriftReportTriggered:
+    def test_no_drift(self):
+        report = DriftReport()
+        assert report.triggered({"orphan_triage": 50}) is None
+
+    def test_orphan_triage_triggered(self):
+        report = DriftReport(
+            orphaned_concepts=[{"name": f"c{i}"} for i in range(51)]
+        )
+        assert report.triggered({"orphan_triage": 50}) == "orphan_triage"
+
+    def test_orphan_triage_at_threshold_not_triggered(self):
+        report = DriftReport(
+            orphaned_concepts=[{"name": f"c{i}"} for i in range(50)]
+        )
+        assert report.triggered({"orphan_triage": 50}) is None
+
+    def test_contested_review_triggered(self):
+        report = DriftReport(
+            contested_claims=[{"name": "claim1", "days_old": 20}]
+        )
+        assert report.triggered({}) == "contested_review"
+
+    def test_stale_unverified_triggered(self):
+        report = DriftReport(
+            stale_unverified=[{"name": "claim1", "days_old": 35}]
+        )
+        assert report.triggered({}) == "stale_unverified"
+
+    def test_workflow_synthesis_triggered(self):
+        report = DriftReport(
+            workflow_repetitions=[{"name": f"w{i}"} for i in range(4)]
+        )
+        assert report.triggered({"workflow_repetition": 3}) == "workflow_synthesis"
+
+    def test_priority_order_orphan_over_contested(self):
+        report = DriftReport(
+            orphaned_concepts=[{"name": f"c{i}"} for i in range(4)],
+            contested_claims=[{"name": "claim1"}],
+        )
+        assert report.triggered({"orphan_triage": 3}) == "orphan_triage"
+
+    def test_priority_order_contested_over_stale(self):
+        report = DriftReport(
+            contested_claims=[{"name": "claim1"}],
+            stale_unverified=[{"name": "claim2"}],
+        )
+        assert report.triggered({}) == "contested_review"
+
+
+# ------------------------------------------------------------------
+# Code path extraction
+# ------------------------------------------------------------------
+
+
+class TestExtractCodePaths:
+    def test_single_path(self):
+        text = "## C001: foo (ACTIVE)\n- **Code:** `src/foo.py`\n"
+        assert _extract_code_paths(text) == ["src/foo.py"]
+
+    def test_multiple_comma_separated(self):
+        text = "- **Code:** `src/a.py`, `src/b.py`\n"
+        assert _extract_code_paths(text) == ["src/a.py", "src/b.py"]
+
+    def test_no_backticks(self):
+        text = "- **Code:** src/foo.py\n"
+        assert _extract_code_paths(text) == ["src/foo.py"]
+
+    def test_no_code_field(self):
+        text = "## C001: foo (ACTIVE)\n- **Issues:** #42\n"
+        assert _extract_code_paths(text) == []
+
+
+# ------------------------------------------------------------------
+# Orphan detection
+# ------------------------------------------------------------------
+
+
+class TestFindOrphanedConcepts:
+    def test_finds_orphans(self, project):
+        registry = project / "docs" / "decisions" / "concept_registry.md"
+        registry.write_text(
+            "# Concept Registry\n\n"
+            "## C001: real_module (ACTIVE)\n"
+            "- **Code:** `src/missing.py`\n\n"
+            "## C002: present_module (ACTIVE)\n"
+            "- **Code:** `src/present.py`\n"
+        )
+        # Create only the present file
+        (project / "src").mkdir()
+        (project / "src" / "present.py").write_text("")
+
+        orphans = _find_orphaned_concepts(registry, project)
+        assert len(orphans) == 1
+        assert orphans[0]["id"] == "C001"
+        assert "src/missing.py" in orphans[0]["paths"]
+
+    def test_skips_dead_entries(self, project):
+        registry = project / "docs" / "decisions" / "concept_registry.md"
+        registry.write_text(
+            "# Concept Registry\n\n"
+            "## C001: dead_concept (DEAD) \u2192 concept_graveyard.md#C001\n"
+        )
+        orphans = _find_orphaned_concepts(registry, project)
+        assert orphans == []
+
+    def test_skips_entries_without_code(self, project):
+        registry = project / "docs" / "decisions" / "concept_registry.md"
+        registry.write_text(
+            "# Concept Registry\n\n"
+            "## C001: abstract_concept (ACTIVE)\n"
+            "- **Issues:** #5\n"
+        )
+        orphans = _find_orphaned_concepts(registry, project)
+        assert orphans == []
+
+    def test_empty_registry(self, project):
+        registry = project / "docs" / "decisions" / "concept_registry.md"
+        registry.write_text("# Concept Registry\n")
+        orphans = _find_orphaned_concepts(registry, project)
+        assert orphans == []
+
+
+# ------------------------------------------------------------------
+# Date extraction
+# ------------------------------------------------------------------
+
+
+class TestExtractLatestDate:
+    def test_single_date(self):
+        text = "- #42: 'some claim' \u2192 contested (2025-06-15)"
+        dt = _extract_latest_date(text)
+        assert dt is not None
+        assert dt.strftime("%Y-%m-%d") == "2025-06-15"
+
+    def test_multiple_dates_returns_latest(self):
+        text = (
+            "- 2025-01-10: first claim\n"
+            "- 2025-06-20: updated claim\n"
+            "- 2025-03-15: mid claim\n"
+        )
+        dt = _extract_latest_date(text)
+        assert dt is not None
+        assert dt.strftime("%Y-%m-%d") == "2025-06-20"
+
+    def test_no_dates(self):
+        assert _extract_latest_date("no dates here") is None
+
+
+# ------------------------------------------------------------------
+# Contested / unverified claim detection
+# ------------------------------------------------------------------
+
+
+class TestFindClaimsByStatus:
+    def test_finds_old_contested(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=20)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            f"## E001: some_claim (contested)\n"
+            f"**History:**\n"
+            f"- #{old_date}: 'initial' \u2192 contested\n"
+        )
+        results = _find_claims_by_status(epistemic, "contested", 14)
+        assert len(results) == 1
+        assert results[0]["id"] == "E001"
+        assert results[0]["days_old"] >= 20
+
+    def test_ignores_recent_contested(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        recent_date = (datetime.now(timezone.utc) - timedelta(days=5)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            f"## E001: new_claim (contested)\n"
+            f"**History:**\n"
+            f"- {recent_date}: 'initial'\n"
+        )
+        results = _find_claims_by_status(epistemic, "contested", 14)
+        assert results == []
+
+    def test_finds_stale_unverified(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=45)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            f"## E002: stale_claim (unverified)\n"
+            f"**History:**\n"
+            f"- {old_date}: first noted\n"
+        )
+        results = _find_claims_by_status(epistemic, "unverified", 30)
+        assert len(results) == 1
+        assert results[0]["id"] == "E002"
+
+    def test_skips_entries_without_dates(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E001: no_date_claim (contested)\n"
+            "**Current position:** Unknown.\n"
+        )
+        results = _find_claims_by_status(epistemic, "contested", 14)
+        assert results == []
+
+
+# ------------------------------------------------------------------
+# Workflow repetition detection
+# ------------------------------------------------------------------
+
+
+class TestFindWorkflowRepetitions:
+    def test_finds_current_workflows(self, project):
+        workflows = project / "docs" / "decisions" / "workflow_registry.md"
+        workflows.write_text(
+            "# Workflow Registry\n\n"
+            "## W001: deploy_process (CURRENT)\n"
+            "- **Context:** production deploys\n\n"
+            "## W002: review_process (CURRENT)\n"
+            "- **Context:** code review\n\n"
+            "## W003: old_process (SUPERSEDED) \u2192 W001\n"
+        )
+        results = _find_workflow_repetitions(workflows)
+        assert len(results) == 2
+        assert results[0]["id"] == "W001"
+        assert results[1]["id"] == "W002"
+
+    def test_empty_workflows(self, project):
+        workflows = project / "docs" / "decisions" / "workflow_registry.md"
+        workflows.write_text("# Workflow Registry\n")
+        assert _find_workflow_repetitions(workflows) == []
+
+
+# ------------------------------------------------------------------
+# Budget computation
+# ------------------------------------------------------------------
+
+
+class TestComputeBudget:
+    def test_basic_budget(self, project, config):
+        from engram.config import resolve_doc_paths
+        paths = resolve_doc_paths(config, project)
+        budget, living_chars = compute_budget(config, paths)
+
+        # With minimal docs (~100 chars total), budget should be near max_chunk
+        assert budget <= 200_000
+        assert budget > 0
+        assert living_chars > 0
+
+    def test_large_docs_reduce_budget(self, project, config):
+        from engram.config import resolve_doc_paths
+        paths = resolve_doc_paths(config, project)
+
+        # Write a large timeline
+        timeline = paths["timeline"]
+        timeline.write_text("x" * 300_000)
+
+        budget, living_chars = compute_budget(config, paths)
+        assert living_chars >= 300_000
+        # Budget = 600k - 300k - 10k = 290k, capped at 200k
+        assert budget == 200_000
+
+    def test_budget_capped_at_max_chunk(self, project, config):
+        from engram.config import resolve_doc_paths
+        paths = resolve_doc_paths(config, project)
+        budget, _ = compute_budget(config, paths)
+        assert budget <= config["budget"]["max_chunk_chars"]
+
+
+# ------------------------------------------------------------------
+# Full scan_drift integration
+# ------------------------------------------------------------------
+
+
+class TestScanDrift:
+    def test_no_drift_on_empty_docs(self, project, config):
+        report = scan_drift(config, project)
+        assert report.orphaned_concepts == []
+        assert report.contested_claims == []
+        assert report.stale_unverified == []
+        assert report.workflow_repetitions == []
+        assert report.triggered(config["thresholds"]) is None
+
+    def test_orphan_drift_triggered(self, project, config):
+        registry = project / "docs" / "decisions" / "concept_registry.md"
+        entries = "# Concept Registry\n\n"
+        for i in range(4):
+            entries += f"## C{i:03d}: concept_{i} (ACTIVE)\n- **Code:** `missing/{i}.py`\n\n"
+        registry.write_text(entries)
+
+        report = scan_drift(config, project)
+        assert len(report.orphaned_concepts) == 4
+        # threshold is 3, so 4 > 3 triggers
+        assert report.triggered(config["thresholds"]) == "orphan_triage"
+
+
+# ------------------------------------------------------------------
+# Item rendering
+# ------------------------------------------------------------------
+
+
+class TestRenderItemContent:
+    def test_doc_initial(self, project):
+        doc_path = project / "docs" / "working" / "spec.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("# Spec\nSome content here.\n")
+
+        item = _make_doc_item(path="docs/working/spec.md", date="2025-03-10T12:00:00")
+        result = _render_item_content(item, project)
+        assert "## [INITIAL] Doc: docs/working/spec.md" in result
+        assert "2025-03-10" in result
+        assert "Some content here." in result
+
+    def test_doc_revisit(self, project):
+        doc_path = project / "docs" / "working" / "spec.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("# Updated spec\n")
+
+        item = {
+            "date": "2025-06-01T00:00:00",
+            "type": "doc",
+            "path": "docs/working/spec.md",
+            "chars": 100,
+            "pass": "revisit",
+            "first_seen_date": "2025-03-10T00:00:00",
+        }
+        result = _render_item_content(item, project)
+        assert "[REVISIT]" in result
+        assert "First seen:" in result
+        assert "updated since first processed" in result
+
+    def test_issue_item(self, project):
+        issue_dir = project / "local_data" / "issues"
+        issue_dir.mkdir(parents=True)
+        issue_data = {
+            "number": 42,
+            "title": "Fix bug",
+            "body": "Description here",
+            "state": "open",
+            "createdAt": "2025-04-01T00:00:00Z",
+            "labels": [],
+            "comments": [],
+        }
+        (issue_dir / "42.json").write_text(json.dumps(issue_data))
+
+        item = {
+            "date": "2025-04-01T00:00:00Z",
+            "type": "issue",
+            "path": "local_data/issues/42.json",
+            "chars": 200,
+            "pass": "initial",
+            "issue_number": 42,
+            "issue_title": "Fix bug",
+        }
+        result = _render_item_content(item, project)
+        assert "Issue #42: Fix bug" in result
+
+    def test_missing_file_graceful(self, project):
+        item = _make_doc_item(path="nonexistent.md")
+        result = _render_item_content(item, project)
+        assert "FILE NOT FOUND" in result
+
+    def test_prompts_item(self, project):
+        session_dir = project / ".engram" / "sessions"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / "abc123.md").write_text("User: do the thing\n")
+
+        item = {
+            "date": "2025-05-01T00:00:00",
+            "type": "prompts",
+            "path": ".engram/sessions/abc123.md",
+            "chars": 100,
+            "pass": "initial",
+            "session_id": "abc123",
+            "prompt_count": 5,
+        }
+        result = _render_item_content(item, project)
+        assert "[USER PROMPTS] Session (5 prompts)" in result
+        assert "do the thing" in result
+
+
+# ------------------------------------------------------------------
+# next_chunk integration
+# ------------------------------------------------------------------
+
+
+class TestNextChunk:
+    def test_normal_chunk(self, project, config):
+        # Create a doc to reference from the queue
+        doc_path = project / "docs" / "working" / "spec.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("# Test Spec\nContent for the chunk.\n")
+
+        _write_queue(project, [
+            _make_doc_item(path="docs/working/spec.md", chars=100),
+        ])
+
+        result = next_chunk(config, project)
+        assert result.chunk_type == "fold"
+        assert result.chunk_id == 1
+        assert result.items_count == 1
+        assert result.input_path.exists()
+        assert result.prompt_path.exists()
+        assert result.remaining_queue == 0
+
+        # Verify input file content
+        input_text = result.input_path.read_text()
+        assert "# Instructions" in input_text
+        assert "Content for the chunk." in input_text
+
+        # Verify prompt file content
+        prompt_text = result.prompt_path.read_text()
+        assert "knowledge fold chunk" in prompt_text
+
+    def test_drift_triage_chunk(self, project, config):
+        # Create orphaned concepts exceeding threshold (3)
+        registry = project / "docs" / "decisions" / "concept_registry.md"
+        entries = "# Concept Registry\n\n"
+        for i in range(4):
+            entries += f"## C{i:03d}: orphan_{i} (ACTIVE)\n- **Code:** `gone/{i}.py`\n\n"
+        registry.write_text(entries)
+
+        _write_queue(project, [
+            _make_doc_item(chars=100),
+        ])
+
+        result = next_chunk(config, project)
+        assert result.chunk_type == "orphan_triage"
+        assert result.items_count == 0
+        assert result.drift_entry_count == 4
+        assert result.remaining_queue == 1  # queue not consumed
+
+        input_text = result.input_path.read_text()
+        assert "Orphan Triage Round" in input_text
+        assert "orphan_0" in input_text
+
+    def test_queue_not_found_raises(self, project, config):
+        with pytest.raises(FileNotFoundError, match="No queue found"):
+            next_chunk(config, project)
+
+    def test_empty_queue_raises(self, project, config):
+        _write_queue(project, [])
+        with pytest.raises(ValueError, match="Queue is empty"):
+            next_chunk(config, project)
+
+    def test_multiple_chunks_increment_id(self, project, config):
+        doc_path = project / "docs" / "working" / "a.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("A")
+        doc_b = project / "docs" / "working" / "b.md"
+        doc_b.write_text("B")
+
+        # Use chars large enough that both won't fit in max_chunk_chars
+        config["budget"]["max_chunk_chars"] = 150
+
+        _write_queue(project, [
+            _make_doc_item(path="docs/working/a.md", chars=100, date="2025-01-01T00:00:00"),
+            _make_doc_item(path="docs/working/b.md", chars=100, date="2025-02-01T00:00:00"),
+        ])
+
+        r1 = next_chunk(config, project)
+        assert r1.chunk_id == 1
+        assert r1.remaining_queue == 1
+
+        r2 = next_chunk(config, project)
+        assert r2.chunk_id == 2
+        assert r2.remaining_queue == 0
+
+    def test_oversized_single_item(self, project, config):
+        doc_path = project / "docs" / "working" / "huge.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("x" * 300_000)
+
+        _write_queue(project, [
+            _make_doc_item(path="docs/working/huge.md", chars=300_000),
+        ])
+
+        result = next_chunk(config, project)
+        assert result.chunk_type == "fold"
+        assert result.items_count == 1
+
+    def test_budget_limits_items(self, project, config):
+        # Create multiple doc files
+        (project / "docs" / "working").mkdir(parents=True, exist_ok=True)
+        items = []
+        for i in range(10):
+            p = f"docs/working/doc_{i}.md"
+            (project / p).write_text(f"Content {i}\n")
+            items.append(_make_doc_item(
+                path=p,
+                chars=50_000,
+                date=f"2025-01-{i+1:02d}T00:00:00",
+            ))
+
+        _write_queue(project, items)
+
+        result = next_chunk(config, project)
+        # Budget is ~200k, each item is 50k chars, so should fit 4 items
+        assert result.items_count == 4
+        assert result.remaining_queue == 6
+
+    def test_manifest_written(self, project, config):
+        doc_path = project / "docs" / "working" / "spec.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("Spec")
+
+        _write_queue(project, [_make_doc_item(path="docs/working/spec.md", chars=100)])
+
+        next_chunk(config, project)
+        manifest = project / ".engram" / "chunks_manifest.yaml"
+        assert manifest.exists()
+        text = manifest.read_text()
+        assert "id: 1" in text
+        assert "input_file: chunk_001_input.md" in text
+
+    def test_id_pre_assignment(self, project, config):
+        doc_path = project / "docs" / "working" / "spec.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("Spec")
+
+        # Queue item with entity hints
+        item = _make_doc_item(path="docs/working/spec.md", chars=100)
+        item["entity_hints"] = [
+            {"category": "C"},
+            {"category": "C"},
+            {"category": "E"},
+        ]
+        _write_queue(project, [item])
+
+        result = next_chunk(config, project)
+        assert "C" in result.pre_assigned_ids
+        assert len(result.pre_assigned_ids["C"]) == 2
+        assert "E" in result.pre_assigned_ids
+        assert len(result.pre_assigned_ids["E"]) == 1
+        # IDs should be formatted correctly
+        assert result.pre_assigned_ids["C"][0].startswith("C")
+
+        # Verify IDs appear in input file
+        input_text = result.input_path.read_text()
+        for cid in result.pre_assigned_ids["C"]:
+            assert cid in input_text


### PR DESCRIPTION
## Summary

- **engram/fold/chunker.py**: Chunk assembly with drift-priority scheduling across all 4 threshold types (orphaned concepts, contested claims, stale unverified claims, workflow repetitions). Dynamic budget: `context_limit - living_docs - overhead`, capped at `max_chunk_chars`. Includes pre-assigned IDs from `ids.py` (#5).
- **engram/fold/prompt.py**: Jinja2 template rendering for fold prompt, triage prompt, seed prompt, and agent execution prompt.
- **engram/templates/**: `fold_prompt.md` (v3 system instructions: 4 docs, stable IDs, FULL/STUB forms, graveyard move instructions), `triage_prompt.md` (handles all 4 drift types), `seed_prompt.md` (bootstrap).
- **CLI**: `engram next-chunk` command with full progress reporting.
- **tests/test_chunker.py**: 44 tests covering all drift detection types, budget math, ID pre-assignment, item rendering, and end-to-end chunk assembly.

## Spec Reference

`specs/2_v3_implementation.md` section '#8 — Chunk assembly + prompt rendering'

## Test Plan

- [x] `python -m pytest tests/test_chunker.py -v` — 44 tests pass
- [x] Full suite `python -m pytest tests/ -v` — 271 tests pass, no regressions
- [x] Drift priority order: orphans > contested > stale > workflow
- [x] Budget correctly computed as `context_limit - living_docs_chars - overhead`, capped at `max_chunk_chars`
- [x] Pre-assigned IDs appear in chunk input file
- [x] Triage chunks don't consume queue items
- [x] Oversized single items handled gracefully
- [x] Manifest appended correctly

Fixes #8