### PR TITLE
Fix drift threshold counts and clamp negative chunk budget

### DIFF
--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -39,9 +39,9 @@ class DriftReport:
         """
         if len(self.orphaned_concepts) > thresholds.get("orphan_triage", 50):
             return "orphan_triage"
-        if self.contested_claims:
+        if len(self.contested_claims) > thresholds.get("contested_review", 5):
             return "contested_review"
-        if self.stale_unverified:
+        if len(self.stale_unverified) > thresholds.get("stale_unverified", 10):
             return "stale_unverified"
         if len(self.workflow_repetitions) > thresholds.get("workflow_repetition", 3):
             return "workflow_synthesis"
@@ -219,7 +219,8 @@ def compute_budget(config: dict, doc_paths: dict[str, Path]) -> tuple[int, int]:
             living_docs_chars += len(p.read_text())
 
     remaining = context_limit - living_docs_chars - overhead
-    return min(remaining, max_chunk), living_docs_chars
+    budget = min(max(0, remaining), max_chunk)
+    return budget, living_docs_chars
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **#18:** `DriftReport.triggered()` now applies count thresholds for contested (>5) and stale_unverified (>10) drift types per the scheduling priority table in `engram_idea.md`, instead of triggering on any >=1 aged claim.
- **#19:** `compute_budget()` clamps the computed budget to `max(0, remaining)` so oversized living docs can't produce a negative budget.

Fixes #18, Fixes #19

## Test plan
- [x] Updated existing tests for contested/stale_unverified to use counts exceeding new thresholds
- [x] Added boundary tests: `test_contested_review_at_threshold_not_triggered` (5 items = no trigger), `test_stale_unverified_at_threshold_not_triggered` (10 items = no trigger)
- [x] Added `test_negative_budget_clamped_to_zero` — writes 600K living doc, verifies budget == 0
- [x] All 274 tests pass