### PR TITLE
Implement stable ID migration for v2 living docs (#11)

### DIFF
--- a/engram/cli.py
+++ b/engram/cli.py
@@ -262,8 +262,6 @@ def lint(project_root: str) -> None:
 )
 def migrate(project_root: str, fold_from: object) -> None:
     """Migrate v2 living docs to v3 format (one-time)."""
-    from datetime import date as date_type
-
     from engram.migrate import migrate as run_migrate
 
     root = Path(project_root)


### PR DESCRIPTION
## Summary

- Add `engram migrate [--fold-from YYYY-MM-DD]` CLI command for one-time v2 → v3 migration
- New `engram/migrate.py` module with 7-phase pipeline: ID backfill, 4th doc (workflow) extraction, graveyard bootstrapping, cross-reference rewrite, counter initialization, fold continuation marker, linter validation
- 35 tests covering all phases plus idempotency and integration

## Spec Reference

`specs/2_v3_implementation.md` — ticket #11 (Stable ID migration for existing v2 docs)

## Test Plan

- [x] Unit tests for each migration phase (backfill, extraction, graveyard, cross-ref, counters, fold marker)
- [x] Integration tests for full migration pipeline
- [x] Idempotency verified (running twice produces identical results)
- [x] Linter passes on migrated docs
- [x] Full test suite passes (309/309)

Fixes #11