### PR TITLE
Temporal orphan triage: check fold-from date, not today

### DIFF
--- a/engram/cli.py
+++ b/engram/cli.py
@@ -185,12 +185,16 @@ def next_chunk_cmd(project_root: str) -> None:
     """Build the next chunk input and prompt files."""
     from engram.config import load_config
     from engram.fold.chunker import next_chunk
+    from engram.server.db import ServerDB
 
     root = Path(project_root)
     config = load_config(root)
 
+    db = ServerDB(root / ".engram" / "engram.db")
+    fold_from = db.get_fold_from()
+
     try:
-        result = next_chunk(config, root)
+        result = next_chunk(config, root, fold_from=fold_from)
     except FileNotFoundError as exc:
         click.echo(str(exc))
         raise SystemExit(1)

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -72,8 +72,15 @@ def render_triage_input(
     drift_report: Any,
     chunk_id: int,
     doc_paths: dict[str, Path],
+    ref_commit: str | None = None,
+    ref_date: str | None = None,
 ) -> str:
-    """Render a drift-triage chunk's input.md file."""
+    """Render a drift-triage chunk's input.md file.
+
+    When *ref_commit* and *ref_date* are provided, the template
+    includes a temporal context block instructing the agent to check
+    file existence at the reference commit, not today's filesystem.
+    """
     env = _get_env()
     template = env.get_template("triage_prompt.md")
 
@@ -94,6 +101,8 @@ def render_triage_input(
         chunk_id=chunk_id,
         doc_paths=_stringify_paths(doc_paths),
         entry_count=len(entries),
+        ref_commit=ref_commit,
+        ref_date=ref_date,
     )
 
 

--- a/engram/migrate.py
+++ b/engram/migrate.py
@@ -404,25 +404,13 @@ def initialize_counters(
 def set_fold_marker(db_path: Path, fold_from: date) -> None:
     """Set the fold continuation marker in SQLite.
 
-    Creates or updates the server_state table with the fold-from date.
+    Uses ServerDB to ensure the table always has the correct
+    singleton-row schema, handling legacy migration if needed.
     """
-    conn = sqlite3.connect(str(db_path))
-    try:
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS server_state (
-                key   TEXT PRIMARY KEY,
-                value TEXT NOT NULL
-            )
-            """
-        )
-        conn.execute(
-            "INSERT OR REPLACE INTO server_state (key, value) VALUES (?, ?)",
-            ("fold_from", fold_from.isoformat()),
-        )
-        conn.commit()
-    finally:
-        conn.close()
+    from engram.server.db import ServerDB
+
+    db = ServerDB(db_path)
+    db.set_fold_from(fold_from.isoformat())
 
 
 # ------------------------------------------------------------------

--- a/engram/server/buffer.py
+++ b/engram/server/buffer.py
@@ -76,7 +76,8 @@ class ContextBuffer:
         Reasons: ``"buffer_full"``, ``"drift:<type>"``.
         """
         # Check drift thresholds
-        drift = scan_drift(self._config, self._project_root)
+        fold_from = self._db.get_fold_from()
+        drift = scan_drift(self._config, self._project_root, fold_from=fold_from)
         thresholds = self._config.get("thresholds", {})
         drift_type = drift.triggered(thresholds)
         if drift_type:

--- a/engram/server/dispatcher.py
+++ b/engram/server/dispatcher.py
@@ -66,7 +66,8 @@ class Dispatcher:
 
         # Build the chunk
         try:
-            chunk = next_chunk(self._config, self._project_root)
+            fold_from = self._db.get_fold_from()
+            chunk = next_chunk(self._config, self._project_root, fold_from=fold_from)
         except (FileNotFoundError, ValueError) as exc:
             log.warning("Cannot build chunk: %s", exc)
             return False

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -40,6 +40,27 @@ is never a valid reason to skip triage. For each one:
 
 ({{ entry_count }} orphaned concepts to resolve)
 
+{% if ref_commit %}
+## Temporal Context
+
+Living docs are current through **{{ ref_date }}** (commit `{{ ref_commit[:12] }}`).
+Check file existence at that commit, NOT today's filesystem.
+
+To inspect files at the reference point:
+```
+git worktree add /tmp/engram-triage-{{ ref_commit[:8] }} {{ ref_commit }}
+```
+
+Check paths in that worktree. When done:
+```
+git worktree remove /tmp/engram-triage-{{ ref_commit[:8] }}
+```
+
+If a file exists at that commit but is missing today, it was renamed/moved AFTER
+the date living docs know about — leave it ACTIVE. The fold will process the
+rename when it reaches that date in the queue.
+{% endif %}
+
 **Goal: get orphan count to 0.** Every entry must be resolved.
 {% elif drift_type == "contested_review" %}
 # Contested Claims Review (Chunk {{ chunk_id }})

--- a/tests/test_temporal_orphan_triage.py
+++ b/tests/test_temporal_orphan_triage.py
@@ -1,0 +1,620 @@
+"""Tests for temporal orphan triage (#25).
+
+Covers: git-based orphan detection, temporal prompt rendering,
+fold_from lifecycle (set/use/clear), legacy schema migration,
+zero-work fold_from clearing.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from engram.server.db import ServerDB
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / ".engram" / "engram.db"
+
+
+@pytest.fixture()
+def db(db_path: Path) -> ServerDB:
+    return ServerDB(db_path)
+
+
+# ==================================================================
+# 1. ServerDB: fold_from accessors
+# ==================================================================
+
+
+class TestFoldFromAccessors:
+    def test_get_fold_from_default_none(self, db: ServerDB) -> None:
+        assert db.get_fold_from() is None
+
+    def test_set_and_get_fold_from(self, db: ServerDB) -> None:
+        db.set_fold_from("2026-01-01")
+        assert db.get_fold_from() == "2026-01-01"
+
+    def test_clear_fold_from(self, db: ServerDB) -> None:
+        db.set_fold_from("2026-01-01")
+        db.clear_fold_from()
+        assert db.get_fold_from() is None
+
+    def test_set_fold_from_overwrites(self, db: ServerDB) -> None:
+        db.set_fold_from("2026-01-01")
+        db.set_fold_from("2026-02-15")
+        assert db.get_fold_from() == "2026-02-15"
+
+    def test_fold_from_column_exists(self, db_path: Path) -> None:
+        """Verify the fold_from column is in the schema."""
+        ServerDB(db_path)
+        conn = sqlite3.connect(str(db_path))
+        cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(server_state)").fetchall()
+        }
+        conn.close()
+        assert "fold_from" in cols
+
+    def test_fold_from_survives_reinit(self, db_path: Path) -> None:
+        """Re-initializing ServerDB preserves fold_from."""
+        db1 = ServerDB(db_path)
+        db1.set_fold_from("2026-01-01")
+        db2 = ServerDB(db_path)
+        assert db2.get_fold_from() == "2026-01-01"
+
+
+# ==================================================================
+# 2. Legacy schema migration
+# ==================================================================
+
+
+class TestLegacySchemaDetection:
+    def _create_legacy_table(self, db_path: Path, fold_from: str | None = None) -> None:
+        """Create the legacy key-value server_state table."""
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE server_state (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        if fold_from:
+            conn.execute(
+                "INSERT INTO server_state (key, value) VALUES ('fold_from', ?)",
+                (fold_from,),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_detects_and_rebuilds_legacy_schema(self, db_path: Path) -> None:
+        """Legacy key-value table is replaced with singleton-row schema."""
+        self._create_legacy_table(db_path, "2026-01-01")
+        db = ServerDB(db_path)
+
+        # Verify schema is now singleton-row
+        conn = sqlite3.connect(str(db_path))
+        cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(server_state)").fetchall()
+        }
+        conn.close()
+        assert "id" in cols
+        assert "key" not in cols
+
+    def test_preserves_fold_from_across_migration(self, db_path: Path) -> None:
+        """fold_from value survives legacy → singleton migration."""
+        self._create_legacy_table(db_path, "2026-01-15")
+        db = ServerDB(db_path)
+        assert db.get_fold_from() == "2026-01-15"
+
+    def test_legacy_table_without_fold_from(self, db_path: Path) -> None:
+        """Legacy table with no fold_from key migrates cleanly."""
+        self._create_legacy_table(db_path, fold_from=None)
+        db = ServerDB(db_path)
+        assert db.get_fold_from() is None
+        # Should still be functional
+        state = db.get_server_state()
+        assert state["buffer_chars_total"] == 0
+
+    def test_singleton_schema_unaffected(self, db_path: Path) -> None:
+        """An existing singleton schema is not touched by migration logic."""
+        db1 = ServerDB(db_path)
+        db1.set_fold_from("2026-03-01")
+        db1.add_buffer_item("test.md", "doc", 100)
+
+        # Re-init — should not lose data
+        db2 = ServerDB(db_path)
+        assert db2.get_fold_from() == "2026-03-01"
+        assert len(db2.get_buffer_items()) == 1
+
+
+# ==================================================================
+# 3. migrate.py set_fold_marker uses ServerDB
+# ==================================================================
+
+
+class TestSetFoldMarker:
+    def test_set_fold_marker_creates_singleton_schema(self, db_path: Path) -> None:
+        from engram.migrate import set_fold_marker
+
+        set_fold_marker(db_path, date(2026, 1, 1))
+
+        # Verify singleton schema (not key-value)
+        conn = sqlite3.connect(str(db_path))
+        cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(server_state)").fetchall()
+        }
+        conn.close()
+        assert "id" in cols
+        assert "key" not in cols
+
+    def test_set_fold_marker_readable_by_server_db(self, db_path: Path) -> None:
+        from engram.migrate import set_fold_marker
+
+        set_fold_marker(db_path, date(2026, 2, 10))
+        db = ServerDB(db_path)
+        assert db.get_fold_from() == "2026-02-10"
+
+
+# ==================================================================
+# 4. Git-based file existence checking
+# ==================================================================
+
+
+class TestGitHelpers:
+    def test_resolve_ref_commit_returns_hash(self, tmp_path: Path) -> None:
+        """In a real git repo, _resolve_ref_commit returns a commit hash."""
+        from engram.fold.chunker import _resolve_ref_commit
+
+        # Create a minimal git repo with a commit
+        _init_git_repo(tmp_path)
+
+        commit = _resolve_ref_commit(tmp_path, "2099-12-31")
+        assert commit is not None
+        assert len(commit) == 40  # Full SHA
+
+    def test_resolve_ref_commit_returns_none_for_ancient_date(
+        self, tmp_path: Path,
+    ) -> None:
+        from engram.fold.chunker import _resolve_ref_commit
+
+        _init_git_repo(tmp_path)
+        # Date before the repo existed
+        assert _resolve_ref_commit(tmp_path, "1900-01-01") is None
+
+    def test_resolve_ref_commit_returns_none_for_non_repo(
+        self, tmp_path: Path,
+    ) -> None:
+        from engram.fold.chunker import _resolve_ref_commit
+
+        assert _resolve_ref_commit(tmp_path, "2026-01-01") is None
+
+    def test_file_exists_at_commit(self, tmp_path: Path) -> None:
+        from engram.fold.chunker import _file_exists_at_commit
+
+        commit = _init_git_repo(tmp_path)
+
+        assert _file_exists_at_commit(tmp_path, commit, "hello.txt")
+        assert not _file_exists_at_commit(tmp_path, commit, "missing.txt")
+
+    def test_file_exists_at_commit_tracks_rename(self, tmp_path: Path) -> None:
+        """After renaming, old name exists at old commit, new name at new."""
+        from engram.fold.chunker import _file_exists_at_commit
+
+        import subprocess
+
+        commit1 = _init_git_repo(tmp_path)
+
+        # Rename the file
+        old = tmp_path / "hello.txt"
+        new = tmp_path / "goodbye.txt"
+        old.rename(new)
+        subprocess.run(
+            ["git", "add", "-A"],
+            cwd=str(tmp_path), capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "rename"],
+            cwd=str(tmp_path), capture_output=True, check=True,
+        )
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(tmp_path), capture_output=True, text=True, check=True,
+        )
+        commit2 = result.stdout.strip()
+
+        # Old commit has old name
+        assert _file_exists_at_commit(tmp_path, commit1, "hello.txt")
+        assert not _file_exists_at_commit(tmp_path, commit1, "goodbye.txt")
+
+        # New commit has new name
+        assert not _file_exists_at_commit(tmp_path, commit2, "hello.txt")
+        assert _file_exists_at_commit(tmp_path, commit2, "goodbye.txt")
+
+
+# ==================================================================
+# 5. Orphan detection with temporal reference
+# ==================================================================
+
+
+class TestTemporalOrphanDetection:
+    def test_orphan_detected_without_ref_commit(self, tmp_path: Path) -> None:
+        """Steady-state: missing files flagged as orphans (filesystem check)."""
+        from engram.fold.chunker import _find_orphaned_concepts
+
+        concepts = tmp_path / "concepts.md"
+        concepts.write_text(
+            "# Concept Registry\n\n"
+            "## C001: Widget (ACTIVE)\n"
+            "- **Code:** `src/widget.py`\n"
+        )
+        # src/widget.py does NOT exist
+
+        orphans = _find_orphaned_concepts(concepts, tmp_path)
+        assert len(orphans) == 1
+        assert orphans[0]["id"] == "C001"
+
+    def test_no_orphan_when_file_exists_at_ref_commit(self, tmp_path: Path) -> None:
+        """With ref_commit, file present at that commit is NOT an orphan."""
+        from engram.fold.chunker import _find_orphaned_concepts
+
+        import subprocess
+
+        # Set up git repo with src/widget.py
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "widget.py").write_text("# widget")
+        commit = _init_git_repo(tmp_path, files=["src/widget.py"])
+
+        # Now delete the file from the filesystem (simulating a rename after fold_from)
+        (tmp_path / "src" / "widget.py").unlink()
+
+        concepts = tmp_path / "concepts.md"
+        concepts.write_text(
+            "# Concept Registry\n\n"
+            "## C001: Widget (ACTIVE)\n"
+            "- **Code:** `src/widget.py`\n"
+        )
+
+        # Without ref_commit — filesystem check → orphan
+        orphans = _find_orphaned_concepts(concepts, tmp_path)
+        assert len(orphans) == 1
+
+        # With ref_commit — file existed at that commit → NOT orphan
+        orphans = _find_orphaned_concepts(concepts, tmp_path, ref_commit=commit)
+        assert len(orphans) == 0
+
+    def test_orphan_when_file_missing_at_ref_commit(self, tmp_path: Path) -> None:
+        """With ref_commit, file missing at that commit IS an orphan."""
+        from engram.fold.chunker import _find_orphaned_concepts
+
+        commit = _init_git_repo(tmp_path)
+
+        concepts = tmp_path / "concepts.md"
+        concepts.write_text(
+            "# Concept Registry\n\n"
+            "## C001: Widget (ACTIVE)\n"
+            "- **Code:** `src/widget.py`\n"
+        )
+
+        orphans = _find_orphaned_concepts(concepts, tmp_path, ref_commit=commit)
+        assert len(orphans) == 1
+        assert orphans[0]["id"] == "C001"
+
+
+# ==================================================================
+# 6. scan_drift threading
+# ==================================================================
+
+
+class TestScanDriftFoldFrom:
+    def test_scan_drift_passes_fold_from(self, tmp_path: Path) -> None:
+        """scan_drift with fold_from uses git-based detection."""
+        from engram.fold.chunker import scan_drift
+
+        import subprocess
+
+        # Set up a project with config
+        _setup_project(tmp_path)
+
+        # Create a git repo with the source file
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "widget.py").write_text("# widget")
+        _init_git_repo(tmp_path, files=["src/widget.py", ".engram/config.yaml",
+                                         "docs/decisions/concept_registry.md",
+                                         "docs/decisions/timeline.md",
+                                         "docs/decisions/epistemic_state.md",
+                                         "docs/decisions/workflow_registry.md",
+                                         "docs/decisions/concept_graveyard.md",
+                                         "docs/decisions/epistemic_graveyard.md"])
+
+        # Delete the file from filesystem
+        (tmp_path / "src" / "widget.py").unlink()
+
+        # Add orphan concept to registry
+        concepts_path = tmp_path / "docs" / "decisions" / "concept_registry.md"
+        concepts_path.write_text(
+            "# Concept Registry\n\n"
+            "## C001: Widget (ACTIVE)\n"
+            "- **Code:** `src/widget.py`\n"
+        )
+
+        from engram.config import load_config
+        config = load_config(tmp_path)
+        # Lower threshold so it triggers
+        config["thresholds"]["orphan_triage"] = 0
+
+        # Without fold_from — filesystem says file missing → orphan
+        drift_no_fold = scan_drift(config, tmp_path)
+        assert len(drift_no_fold.orphaned_concepts) == 1
+
+        # With fold_from — git says file existed → NOT orphan
+        drift_with_fold = scan_drift(config, tmp_path, fold_from="2099-12-31")
+        assert len(drift_with_fold.orphaned_concepts) == 0
+
+
+# ==================================================================
+# 7. Temporal context in triage prompt
+# ==================================================================
+
+
+class TestTriagePromptTemporalContext:
+    def test_no_temporal_block_without_ref_commit(self, tmp_path: Path) -> None:
+        from engram.fold.prompt import render_triage_input
+        from engram.fold.chunker import DriftReport
+
+        drift = DriftReport(
+            orphaned_concepts=[{"name": "C001: Widget", "id": "C001", "paths": ["src/w.py"]}],
+        )
+        doc_paths = _fake_doc_paths(tmp_path)
+
+        output = render_triage_input(
+            drift_type="orphan_triage",
+            drift_report=drift,
+            chunk_id=1,
+            doc_paths=doc_paths,
+        )
+        assert "Temporal Context" not in output
+
+    def test_temporal_block_with_ref_commit(self, tmp_path: Path) -> None:
+        from engram.fold.prompt import render_triage_input
+        from engram.fold.chunker import DriftReport
+
+        drift = DriftReport(
+            orphaned_concepts=[{"name": "C001: Widget", "id": "C001", "paths": ["src/w.py"]}],
+        )
+        doc_paths = _fake_doc_paths(tmp_path)
+
+        output = render_triage_input(
+            drift_type="orphan_triage",
+            drift_report=drift,
+            chunk_id=1,
+            doc_paths=doc_paths,
+            ref_commit="abc123def456789012345678901234567890abcd",
+            ref_date="2026-01-01",
+        )
+        assert "Temporal Context" in output
+        assert "2026-01-01" in output
+        assert "abc123def456" in output
+        assert "git worktree add" in output
+
+    def test_temporal_block_not_in_contested_review(self, tmp_path: Path) -> None:
+        """Temporal context only appears for orphan triage."""
+        from engram.fold.prompt import render_triage_input
+        from engram.fold.chunker import DriftReport
+
+        drift = DriftReport(
+            contested_claims=[{
+                "name": "E001: Claim", "id": "E001",
+                "days_old": 30, "last_date": "2025-12-01",
+            }],
+        )
+        doc_paths = _fake_doc_paths(tmp_path)
+
+        output = render_triage_input(
+            drift_type="contested_review",
+            drift_report=drift,
+            chunk_id=1,
+            doc_paths=doc_paths,
+            ref_commit="abc123def456",
+            ref_date="2026-01-01",
+        )
+        # The template only has the temporal block inside orphan_triage section
+        assert "Temporal Context" not in output
+
+
+# ==================================================================
+# 8. fold_from lifecycle — set → use → clear
+# ==================================================================
+
+
+class TestFoldFromLifecycle:
+    def test_forward_fold_clears_fold_from_on_empty_queue(
+        self, tmp_path: Path,
+    ) -> None:
+        """Early return (empty queue after date filter) clears fold_from."""
+        _setup_project(tmp_path)
+        _init_git_repo(tmp_path, files=[
+            ".engram/config.yaml",
+            "docs/decisions/timeline.md",
+            "docs/decisions/concept_registry.md",
+            "docs/decisions/epistemic_state.md",
+            "docs/decisions/workflow_registry.md",
+            "docs/decisions/concept_graveyard.md",
+            "docs/decisions/epistemic_graveyard.md",
+        ])
+
+        db_path = tmp_path / ".engram" / "engram.db"
+        db = ServerDB(db_path)
+        db.set_fold_from("2026-01-01")
+
+        # Create an empty queue file (or one where all entries predate fold_from)
+        queue_file = tmp_path / ".engram" / "queue.jsonl"
+        queue_file.write_text("")
+
+        # Mock build_queue to return an empty list
+        with patch("engram.bootstrap.fold.build_queue", return_value=[]):
+            from engram.bootstrap.fold import forward_fold
+            from engram.config import load_config
+
+            result = forward_fold(tmp_path, date(2099, 1, 1))
+
+        assert result is True
+        assert db.get_fold_from() is None
+
+    def test_forward_fold_clears_fold_from_on_success(
+        self, tmp_path: Path,
+    ) -> None:
+        """Normal completion clears fold_from."""
+        import json
+
+        _setup_project(tmp_path)
+        _init_git_repo(tmp_path, files=[
+            ".engram/config.yaml",
+            "docs/decisions/timeline.md",
+            "docs/decisions/concept_registry.md",
+            "docs/decisions/epistemic_state.md",
+            "docs/decisions/workflow_registry.md",
+            "docs/decisions/concept_graveyard.md",
+            "docs/decisions/epistemic_graveyard.md",
+        ])
+
+        db_path = tmp_path / ".engram" / "engram.db"
+        db = ServerDB(db_path)
+        db.set_fold_from("2026-01-01")
+
+        # Create a queue with one entry
+        queue_file = tmp_path / ".engram" / "queue.jsonl"
+        entry = {
+            "path": "docs/working/test.md",
+            "type": "doc",
+            "date": "2026-01-15T00:00:00",
+            "chars": 100,
+            "pass": "initial",
+        }
+        queue_file.write_text(json.dumps(entry) + "\n")
+        # Create the referenced file
+        working_dir = tmp_path / "docs" / "working"
+        working_dir.mkdir(parents=True, exist_ok=True)
+        (working_dir / "test.md").write_text("test content")
+
+        with (
+            patch("engram.bootstrap.fold.build_queue") as mock_bq,
+            patch("engram.bootstrap.fold._dispatch_and_validate", return_value=True),
+        ):
+            mock_bq.return_value = [entry]
+
+            from engram.bootstrap.fold import forward_fold
+
+            result = forward_fold(tmp_path, date(2026, 1, 1))
+
+        assert result is True
+        assert db.get_fold_from() is None
+
+
+# ==================================================================
+# Helpers
+# ==================================================================
+
+
+def _init_git_repo(
+    root: Path,
+    files: list[str] | None = None,
+) -> str:
+    """Initialize a git repo, add files, make initial commit. Returns commit hash."""
+    import subprocess
+
+    subprocess.run(
+        ["git", "init"],
+        cwd=str(root), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=str(root), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=str(root), capture_output=True, check=True,
+    )
+
+    if files is None:
+        # Create a default file
+        (root / "hello.txt").write_text("hello")
+        files = ["hello.txt"]
+
+    for f in files:
+        p = root / f
+        if p.exists():
+            subprocess.run(
+                ["git", "add", f],
+                cwd=str(root), capture_output=True, check=True,
+            )
+    subprocess.run(
+        ["git", "commit", "-m", "initial", "--allow-empty"],
+        cwd=str(root), capture_output=True, check=True,
+    )
+
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(root), capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def _setup_project(root: Path) -> None:
+    """Create a minimal engram project structure."""
+    engram_dir = root / ".engram"
+    engram_dir.mkdir(parents=True, exist_ok=True)
+
+    config_yaml = """\
+living_docs:
+  timeline: docs/decisions/timeline.md
+  concepts: docs/decisions/concept_registry.md
+  epistemic: docs/decisions/epistemic_state.md
+  workflows: docs/decisions/workflow_registry.md
+graveyard:
+  concepts: docs/decisions/concept_graveyard.md
+  epistemic: docs/decisions/epistemic_graveyard.md
+thresholds:
+  orphan_triage: 50
+  contested_review_days: 14
+  stale_unverified_days: 30
+  workflow_repetition: 3
+budget:
+  context_limit_chars: 600000
+  instructions_overhead: 10000
+  max_chunk_chars: 200000
+"""
+    (engram_dir / "config.yaml").write_text(config_yaml)
+
+    docs_dir = root / "docs" / "decisions"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "timeline.md").write_text("# Timeline\n")
+    (docs_dir / "concept_registry.md").write_text("# Concept Registry\n")
+    (docs_dir / "epistemic_state.md").write_text("# Epistemic State\n")
+    (docs_dir / "workflow_registry.md").write_text("# Workflow Registry\n")
+    (docs_dir / "concept_graveyard.md").write_text("# Concept Graveyard\n")
+    (docs_dir / "epistemic_graveyard.md").write_text("# Epistemic Graveyard\n")
+
+
+def _fake_doc_paths(root: Path) -> dict[str, Path]:
+    """Return a doc_paths dict pointing to tmp_path-based paths."""
+    docs = root / "docs" / "decisions"
+    docs.mkdir(parents=True, exist_ok=True)
+    return {
+        "timeline": docs / "timeline.md",
+        "concepts": docs / "concept_registry.md",
+        "epistemic": docs / "epistemic_state.md",
+        "workflows": docs / "workflow_registry.md",
+        "concept_graveyard": docs / "concept_graveyard.md",
+        "epistemic_graveyard": docs / "epistemic_graveyard.md",
+    }


### PR DESCRIPTION
## Summary

- Orphan detection during fold-forward now checks file existence at the `fold_from` git commit instead of today's filesystem, preventing anachronistic DEAD markers
- Reconciles the `server_state` schema conflict between `migrate.py` (key-value) and `db.py` (singleton-row) with automatic legacy detection and rebuild
- Triage prompt includes temporal context (commit hash, date, worktree instructions) so the fold agent knows when to check
- `fold_from` marker is cleared on both success paths in `forward_fold()` (empty queue early-return + normal completion)

## Spec Reference

`specs/25_temporal_orphan_triage.md`

## Files Changed (11)

| File | Change |
|------|--------|
| `engram/server/db.py` | Legacy schema detection + rebuild, `fold_from` column, get/set/clear methods |
| `engram/migrate.py` | `set_fold_marker()` rewritten to use `ServerDB` |
| `engram/fold/chunker.py` | Git helpers (`_resolve_ref_commit`, `_file_exists_at_commit`), `ref_commit` param on `_find_orphaned_concepts`, `fold_from` on `scan_drift`/`next_chunk` |
| `engram/fold/prompt.py` | `ref_commit`/`ref_date` params on `render_triage_input()` |
| `engram/templates/triage_prompt.md` | Conditional temporal context block |
| `engram/bootstrap/fold.py` | Pass `fold_from`, clear on both success paths |
| `engram/cli.py` | `next-chunk` reads `fold_from` from db |
| `engram/server/buffer.py` | `should_dispatch()` passes `fold_from` to `scan_drift()` |
| `engram/server/dispatcher.py` | `dispatch()` passes `fold_from` to `next_chunk()` |
| `tests/test_temporal_orphan_triage.py` | 26 new tests |
| `tests/test_migrate.py` | Updated 3 tests for new schema |

## Test Plan

- [x] 26 new tests pass (git detection, prompt rendering, lifecycle, legacy migration)
- [x] Full suite: 419 passed, 0 failed

Fixes #25