### PR TITLE
L0 briefing: regenerate on queue drain, not per-dispatch

### DIFF
--- a/engram/bootstrap/fold.py
+++ b/engram/bootstrap/fold.py
@@ -22,6 +22,7 @@ from engram.dispatch import invoke_agent, read_docs
 from engram.fold.chunker import ChunkResult, next_chunk
 from engram.fold.queue import build_queue
 from engram.linter import lint_post_dispatch
+from engram.server.briefing import regenerate_l0_briefing
 from engram.server.db import ServerDB
 
 log = logging.getLogger(__name__)
@@ -179,6 +180,12 @@ def forward_fold(
     if failures:
         log.warning("Forward fold completed with %d failed chunk(s)", failures)
         return False
+
+    # Regenerate L0 briefing once after all chunks complete
+    if chunk_count > 0:
+        log.info("Regenerating L0 briefing...")
+        doc_paths = resolve_doc_paths(config, project_root)
+        regenerate_l0_briefing(config, project_root, doc_paths)
 
     db = ServerDB(project_root / ".engram" / "engram.db")
     db.clear_fold_from()

--- a/engram/bootstrap/seed.py
+++ b/engram/bootstrap/seed.py
@@ -25,6 +25,7 @@ from engram.config import load_config, resolve_doc_paths
 from engram.dispatch import invoke_agent
 from engram.fold.ids import IDAllocator
 from engram.fold.prompt import render_seed_prompt
+from engram.server.briefing import regenerate_l0_briefing
 
 log = logging.getLogger(__name__)
 
@@ -301,6 +302,10 @@ def seed(
 
         if not success:
             return False
+
+        # Regenerate L0 briefing after seed succeeds
+        doc_paths = resolve_doc_paths(config, project_root)
+        regenerate_l0_briefing(config, project_root, doc_paths)
 
         # Path A: fold forward after seeding
         if from_date is not None:

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -71,6 +71,31 @@ class ChunkResult:
 
 
 # ------------------------------------------------------------------
+# Queue drain predicate
+# ------------------------------------------------------------------
+
+
+def queue_is_empty(project_root: Path) -> bool:
+    """Return True if the dispatch queue is drained.
+
+    Checks ``.engram/queue.jsonl``: returns True if the file is missing,
+    empty, or contains zero entries.  This is the drain predicate used
+    to decide when L0 briefing should regenerate.
+    """
+    queue_file = project_root / ".engram" / "queue.jsonl"
+    if not queue_file.exists():
+        return True
+    try:
+        text = queue_file.read_text()
+    except OSError:
+        return True
+    for line in text.splitlines():
+        if line.strip():
+            return False
+    return True
+
+
+# ------------------------------------------------------------------
 # Drift detection
 # ------------------------------------------------------------------
 

--- a/engram/server/briefing.py
+++ b/engram/server/briefing.py
@@ -1,0 +1,130 @@
+"""Standalone L0 briefing regeneration.
+
+Extracted from :class:`Dispatcher` so that bootstrap paths (seed, fold)
+can regenerate the briefing without instantiating a Dispatcher.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+def regenerate_l0_briefing(
+    config: dict[str, Any],
+    project_root: Path,
+    doc_paths: dict[str, Path],
+) -> bool:
+    """Regenerate the L0 briefing section in the project's CLAUDE.md.
+
+    Uses a lightweight model call to compress living docs into a
+    concise briefing (~50-100 lines).
+
+    Returns True on success, False on failure.
+    """
+    briefing_cfg = config.get("briefing", {})
+    target_file = project_root / briefing_cfg.get("file", "CLAUDE.md")
+    section_header = briefing_cfg.get("section", "## Project Knowledge Briefing")
+
+    if not target_file.exists():
+        log.warning("Briefing target file not found: %s", target_file)
+        return False
+
+    # Read current living docs for briefing generation
+    living_contents: list[str] = []
+    for key in ("timeline", "concepts", "epistemic", "workflows"):
+        p = doc_paths.get(key)
+        if p and p.exists():
+            content = p.read_text()
+            # Truncate very large docs for briefing generation
+            if len(content) > 10_000:
+                content = content[:10_000] + "\n\n[... truncated for briefing ...]\n"
+            living_contents.append(f"### {key.title()}\n{content}")
+
+    if not living_contents:
+        return False
+
+    # Generate briefing via lightweight model call
+    briefing_text = _generate_briefing(config, project_root, "\n\n".join(living_contents))
+    if not briefing_text:
+        log.warning("L0 briefing generation returned empty result")
+        return False
+
+    # Inject into target file
+    _inject_section(target_file, section_header, briefing_text)
+    log.info("L0 briefing regenerated in %s", target_file)
+    return True
+
+
+def _generate_briefing(
+    config: dict[str, Any],
+    project_root: Path,
+    living_docs_content: str,
+) -> str | None:
+    """Generate L0 briefing by shelling out to a fast model.
+
+    Returns the briefing text, or None on failure.
+    """
+    prompt = (
+        "Compress the following project knowledge into a concise briefing "
+        "(50-100 lines). Focus on: what's alive vs dead, contested claims, "
+        "key workflows, and agent guidance. Use stable IDs (C###/E###/W###).\n\n"
+        f"{living_docs_content}"
+    )
+
+    try:
+        result = subprocess.run(
+            ["claude", "--print", "--model", "haiku", prompt],
+            capture_output=True,
+            text=True,
+            cwd=str(project_root),
+            timeout=120,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        log.warning("L0 briefing generation failed")
+
+    return None
+
+
+def _inject_section(file_path: Path, section_header: str, content: str) -> None:
+    """Inject or replace a section in a file.
+
+    Finds ``section_header`` and replaces everything until the next
+    same-level heading (or EOF) with ``content``.
+    """
+    text = file_path.read_text()
+    header_level = section_header.count("#")
+
+    start = text.find(section_header)
+    if start == -1:
+        # Append section at end
+        if not text.endswith("\n"):
+            text += "\n"
+        text += f"\n{section_header}\n\n{content}\n"
+    else:
+        # Find the end of this section (next same-level or higher heading)
+        section_start = start + len(section_header)
+        rest = text[section_start:]
+        end_offset = len(rest)
+
+        for i, line in enumerate(rest.split("\n")):
+            if i == 0:
+                continue
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                level = len(stripped) - len(stripped.lstrip("#"))
+                if level <= header_level:
+                    end_offset = sum(
+                        len(l) + 1 for l in rest.split("\n")[:i]
+                    )
+                    break
+
+        text = text[:start] + f"{section_header}\n\n{content}\n" + text[section_start + end_offset:]
+
+    file_path.write_text(text)

--- a/engram/server/db.py
+++ b/engram/server/db.py
@@ -516,7 +516,7 @@ class ServerDB:
         Recovery strategy per state:
         - building: discard (rebuild from buffer)
         - dispatched: needs re-check or re-dispatch (returned to caller)
-        - validated: L0 regen incomplete (returned to caller)
+        - validated: mark L0 stale + committed (deferred to queue drain)
 
         Returns list of dispatch records needing attention.
         """

--- a/engram/server/dispatcher.py
+++ b/engram/server/dispatcher.py
@@ -20,7 +20,6 @@ from engram.config import resolve_doc_paths
 from engram.dispatch import invoke_agent, read_docs
 from engram.fold.chunker import ChunkResult, next_chunk
 from engram.linter import LintResult, lint_post_dispatch
-from engram.server.briefing import _inject_section  # re-export for backward compat
 
 log = logging.getLogger(__name__)
 
@@ -294,8 +293,3 @@ def _build_correction_text(chunk: ChunkResult, result: LintResult) -> str:
         f"Please fix these violations in the living docs. "
         f"Re-read the input file at {chunk.input_path.resolve()} for context.\n"
     )
-
-
-
-# _inject_section is imported from engram.server.briefing (see top-level import)
-# and re-exported here for backward compatibility with existing tests.

--- a/engram/server/dispatcher.py
+++ b/engram/server/dispatcher.py
@@ -5,14 +5,13 @@ Handles the dispatch lifecycle::
     building → dispatched → validated → committed
 
 Shells out to a configurable fold agent CLI (``claude``, ``codex``, etc.),
-runs the schema linter on results, auto-retries with correction prompts
-on failure (max 2), and regenerates the L0 briefing after success.
+runs the schema linter on results, and auto-retries with correction prompts
+on failure (max 2).  L0 briefing regeneration is deferred to queue drain.
 """
 
 from __future__ import annotations
 
 import logging
-import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -21,6 +20,7 @@ from engram.config import resolve_doc_paths
 from engram.dispatch import invoke_agent, read_docs
 from engram.fold.chunker import ChunkResult, next_chunk
 from engram.linter import LintResult, lint_post_dispatch
+from engram.server.briefing import _inject_section  # re-export for backward compat
 
 log = logging.getLogger(__name__)
 
@@ -54,8 +54,8 @@ class Dispatcher:
         """Execute a single dispatch cycle.
 
         Builds a chunk via the chunker, dispatches to the fold agent,
-        validates with the linter, retries on failure, and regenerates
-        the L0 briefing on success.
+        and validates with the linter.  On success, marks L0 stale
+        (briefing regeneration deferred to queue drain).
 
         Returns True if dispatch succeeded, False on failure.
         """
@@ -92,9 +92,7 @@ class Dispatcher:
 
         if success:
             self._db.update_dispatch_state(dispatch_id, "validated")
-
-            # Regenerate L0 briefing
-            self._regenerate_l0_briefing(doc_paths)
+            self._db.mark_l0_stale()  # stale BEFORE committed — crash-safe ordering
             self._db.update_dispatch_state(dispatch_id, "committed")
             self._db.update_server_state(
                 last_dispatch_time=datetime.now(timezone.utc).isoformat(),
@@ -170,87 +168,22 @@ class Dispatcher:
 
         return False
 
-    def _regenerate_l0_briefing(self, doc_paths: dict[str, Path]) -> None:
-        """Regenerate the L0 briefing section in the project's CLAUDE.md.
-
-        Uses a lightweight model call to compress living docs into a
-        concise briefing (~50-100 lines).
-        """
-        briefing_cfg = self._config.get("briefing", {})
-        target_file = self._project_root / briefing_cfg.get("file", "CLAUDE.md")
-        section_header = briefing_cfg.get("section", "## Project Knowledge Briefing")
-
-        if not target_file.exists():
-            log.warning("Briefing target file not found: %s", target_file)
-            return
-
-        # Read current living docs for briefing generation
-        living_contents: list[str] = []
-        for key in ("timeline", "concepts", "epistemic", "workflows"):
-            p = doc_paths.get(key)
-            if p and p.exists():
-                content = p.read_text()
-                # Truncate very large docs for briefing generation
-                if len(content) > 10_000:
-                    content = content[:10_000] + "\n\n[... truncated for briefing ...]\n"
-                living_contents.append(f"### {key.title()}\n{content}")
-
-        if not living_contents:
-            return
-
-        # Generate briefing via lightweight model call
-        briefing_text = self._generate_briefing("\n\n".join(living_contents))
-        if not briefing_text:
-            log.warning("L0 briefing generation returned empty result")
-            return
-
-        # Inject into target file
-        _inject_section(target_file, section_header, briefing_text)
-        log.info("L0 briefing regenerated in %s", target_file)
-
-    def _generate_briefing(self, living_docs_content: str) -> str | None:
-        """Generate L0 briefing by shelling out to a fast model.
-
-        Returns the briefing text, or None on failure.
-        """
-        prompt = (
-            "Compress the following project knowledge into a concise briefing "
-            "(50-100 lines). Focus on: what's alive vs dead, contested claims, "
-            "key workflows, and agent guidance. Use stable IDs (C###/E###/W###).\n\n"
-            f"{living_docs_content}"
-        )
-
-        try:
-            result = subprocess.run(
-                ["claude", "--print", "--model", "haiku", prompt],
-                capture_output=True,
-                text=True,
-                cwd=str(self._project_root),
-                timeout=120,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip()
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            log.warning("L0 briefing generation failed")
-
-        return None
-
     def recover_dispatch(self, dispatch: dict[str, Any]) -> bool:
         """Recover a dispatch found in non-terminal state on startup.
 
         Recovery strategy per state:
-        - ``validated``: L0 regen didn't complete. Regenerate and mark committed.
+        - ``validated``: mark L0 stale and committed (L0 regen deferred to drain).
         - ``dispatched``: Agent may have completed. Re-lint; if valid, proceed
-          to L0 regen + committed. If lint fails and retries remain, re-dispatch.
+          to mark L0 stale + committed. If lint fails and retries remain, re-dispatch.
         """
         doc_paths = resolve_doc_paths(self._config, self._project_root)
         dispatch_id = dispatch["id"]
 
         if dispatch["state"] == "validated":
-            # L0 regen didn't complete — regenerate and mark committed
-            self._regenerate_l0_briefing(doc_paths)
+            # mark_l0_stale BEFORE committed — crash-safe ordering
+            self._db.mark_l0_stale()
             self._db.update_dispatch_state(dispatch_id, "committed")
-            log.info("Recovered validated dispatch %d: L0 regen + committed", dispatch_id)
+            log.info("Recovered validated dispatch %d: marked L0 stale + committed", dispatch_id)
             return True
 
         if dispatch["state"] == "dispatched":
@@ -271,7 +204,7 @@ class Dispatcher:
 
                 if result.passed:
                     self._db.update_dispatch_state(dispatch_id, "validated")
-                    self._regenerate_l0_briefing(doc_paths)
+                    self._db.mark_l0_stale()  # stale BEFORE committed
                     self._db.update_dispatch_state(dispatch_id, "committed")
                     log.info("Recovered dispatch %d as committed", dispatch_id)
                     return True
@@ -298,7 +231,7 @@ class Dispatcher:
                         result2 = lint(after2, graveyard2, self._config)
                         if result2.passed:
                             self._db.update_dispatch_state(dispatch_id, "validated")
-                            self._regenerate_l0_briefing(doc_paths)
+                            self._db.mark_l0_stale()  # stale BEFORE committed
                             self._db.update_dispatch_state(dispatch_id, "committed")
                             log.info("Recovery re-dispatch succeeded for dispatch %d", dispatch_id)
                             return True
@@ -363,39 +296,6 @@ def _build_correction_text(chunk: ChunkResult, result: LintResult) -> str:
     )
 
 
-def _inject_section(file_path: Path, section_header: str, content: str) -> None:
-    """Inject or replace a section in a file.
 
-    Finds ``section_header`` and replaces everything until the next
-    same-level heading (or EOF) with ``content``.
-    """
-    text = file_path.read_text()
-    header_level = section_header.count("#")
-
-    start = text.find(section_header)
-    if start == -1:
-        # Append section at end
-        if not text.endswith("\n"):
-            text += "\n"
-        text += f"\n{section_header}\n\n{content}\n"
-    else:
-        # Find the end of this section (next same-level or higher heading)
-        section_start = start + len(section_header)
-        rest = text[section_start:]
-        end_offset = len(rest)
-
-        for i, line in enumerate(rest.split("\n")):
-            if i == 0:
-                continue
-            stripped = line.lstrip()
-            if stripped.startswith("#"):
-                level = len(stripped) - len(stripped.lstrip("#"))
-                if level <= header_level:
-                    end_offset = sum(
-                        len(l) + 1 for l in rest.split("\n")[:i]
-                    )
-                    break
-
-        text = text[:start] + f"{section_header}\n\n{content}\n" + text[section_start + end_offset:]
-
-    file_path.write_text(text)
+# _inject_section is imported from engram.server.briefing (see top-level import)
+# and re-exported here for backward compatibility with existing tests.

--- a/tests/test_l0_drain.py
+++ b/tests/test_l0_drain.py
@@ -1,0 +1,482 @@
+"""Tests for L0 briefing regeneration on queue drain (#24).
+
+Covers:
+- l0_stale DB column + methods
+- queue_is_empty drain predicate
+- Dispatcher marks L0 stale (not regen) on dispatch/recovery
+- Crash-window ordering: stale BEFORE committed
+- Bootstrap fold/seed L0 regen at completion
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from engram.server.db import ServerDB
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / ".engram" / "engram.db"
+
+
+@pytest.fixture()
+def db(db_path: Path) -> ServerDB:
+    return ServerDB(db_path)
+
+
+@pytest.fixture()
+def project(tmp_path: Path) -> Path:
+    """Minimal engram project for testing."""
+    engram_dir = tmp_path / ".engram"
+    engram_dir.mkdir()
+
+    config_yaml = """\
+living_docs:
+  timeline: docs/decisions/timeline.md
+  concepts: docs/decisions/concept_registry.md
+  epistemic: docs/decisions/epistemic_state.md
+  workflows: docs/decisions/workflow_registry.md
+graveyard:
+  concepts: docs/decisions/concept_graveyard.md
+  epistemic: docs/decisions/epistemic_graveyard.md
+thresholds:
+  orphan_triage: 50
+  contested_review_days: 14
+  stale_unverified_days: 30
+  workflow_repetition: 3
+budget:
+  context_limit_chars: 600000
+  instructions_overhead: 10000
+  max_chunk_chars: 200000
+"""
+    (engram_dir / "config.yaml").write_text(config_yaml)
+
+    docs_dir = tmp_path / "docs" / "decisions"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "timeline.md").write_text("# Timeline\n")
+    (docs_dir / "concept_registry.md").write_text("# Concept Registry\n")
+    (docs_dir / "epistemic_state.md").write_text("# Epistemic State\n")
+    (docs_dir / "workflow_registry.md").write_text("# Workflow Registry\n")
+    (docs_dir / "concept_graveyard.md").write_text("# Concept Graveyard\n")
+    (docs_dir / "epistemic_graveyard.md").write_text("# Epistemic Graveyard\n")
+
+    return tmp_path
+
+
+@pytest.fixture()
+def config(project: Path) -> dict:
+    from engram.config import load_config
+    return load_config(project)
+
+
+# ==================================================================
+# DB: l0_stale column and methods
+# ==================================================================
+
+
+class TestL0StaleDB:
+    def test_default_not_stale(self, db: ServerDB) -> None:
+        assert db.is_l0_stale() is False
+
+    def test_mark_stale(self, db: ServerDB) -> None:
+        db.mark_l0_stale()
+        assert db.is_l0_stale() is True
+
+    def test_clear_stale(self, db: ServerDB) -> None:
+        db.mark_l0_stale()
+        db.clear_l0_stale()
+        assert db.is_l0_stale() is False
+
+    def test_mark_stale_idempotent(self, db: ServerDB) -> None:
+        db.mark_l0_stale()
+        db.mark_l0_stale()
+        assert db.is_l0_stale() is True
+
+    def test_column_migration_idempotent(self, db_path: Path) -> None:
+        """Re-initializing DB doesn't fail on existing l0_stale column."""
+        db1 = ServerDB(db_path)
+        db1.mark_l0_stale()
+        # Re-init — should not raise
+        db2 = ServerDB(db_path)
+        assert db2.is_l0_stale() is True
+
+    def test_l0_stale_visible_in_server_state(self, db: ServerDB) -> None:
+        db.mark_l0_stale()
+        state = db.get_server_state()
+        assert state["l0_stale"] == 1
+
+
+# ==================================================================
+# queue_is_empty drain predicate
+# ==================================================================
+
+
+class TestQueueIsEmpty:
+    def test_missing_file(self, tmp_path: Path) -> None:
+        from engram.fold.chunker import queue_is_empty
+        assert queue_is_empty(tmp_path) is True
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        from engram.fold.chunker import queue_is_empty
+        engram_dir = tmp_path / ".engram"
+        engram_dir.mkdir()
+        (engram_dir / "queue.jsonl").write_text("")
+        assert queue_is_empty(tmp_path) is True
+
+    def test_whitespace_only(self, tmp_path: Path) -> None:
+        from engram.fold.chunker import queue_is_empty
+        engram_dir = tmp_path / ".engram"
+        engram_dir.mkdir()
+        (engram_dir / "queue.jsonl").write_text("\n\n  \n")
+        assert queue_is_empty(tmp_path) is True
+
+    def test_non_empty(self, tmp_path: Path) -> None:
+        from engram.fold.chunker import queue_is_empty
+        engram_dir = tmp_path / ".engram"
+        engram_dir.mkdir()
+        entry = {"path": "test.md", "type": "doc", "chars": 100, "date": "2026-01-01"}
+        (engram_dir / "queue.jsonl").write_text(json.dumps(entry) + "\n")
+        assert queue_is_empty(tmp_path) is False
+
+
+# ==================================================================
+# Dispatcher: dispatch() uses mark_l0_stale, not L0 regen
+# ==================================================================
+
+
+class TestDispatcherMarksStale:
+    def test_dispatch_marks_l0_stale_not_regen(self, project: Path, config: dict) -> None:
+        """Successful dispatch should call mark_l0_stale, not regenerate briefing."""
+        from engram.server.dispatcher import Dispatcher
+
+        db = ServerDB(project / ".engram" / "engram.db")
+        dispatcher = Dispatcher(config, project, db)
+
+        # Mock the internals so dispatch succeeds without a real agent
+        with patch.object(dispatcher, "_execute_and_validate", return_value=True), \
+             patch("engram.server.dispatcher.next_chunk") as mock_nc:
+            mock_chunk = MagicMock()
+            mock_chunk.chunk_id = 1
+            mock_nc.return_value = mock_chunk
+
+            result = dispatcher.dispatch()
+
+        assert result is True
+        assert db.is_l0_stale() is True
+
+    def test_failed_dispatch_does_not_mark_stale(self, project: Path, config: dict) -> None:
+        """Failed dispatch should NOT mark L0 stale."""
+        from engram.server.dispatcher import Dispatcher
+
+        db = ServerDB(project / ".engram" / "engram.db")
+        dispatcher = Dispatcher(config, project, db)
+
+        with patch.object(dispatcher, "_execute_and_validate", return_value=False), \
+             patch("engram.server.dispatcher.next_chunk") as mock_nc:
+            mock_chunk = MagicMock()
+            mock_chunk.chunk_id = 1
+            mock_nc.return_value = mock_chunk
+
+            result = dispatcher.dispatch()
+
+        assert result is False
+        assert db.is_l0_stale() is False
+
+
+# ==================================================================
+# Crash-window ordering: stale BEFORE committed
+# ==================================================================
+
+
+class TestCrashWindowOrdering:
+    def test_dispatch_stale_before_committed(self, project: Path, config: dict) -> None:
+        """mark_l0_stale() must be called before update_dispatch_state(committed)."""
+        from engram.server.dispatcher import Dispatcher
+
+        db = ServerDB(project / ".engram" / "engram.db")
+        dispatcher = Dispatcher(config, project, db)
+
+        call_order: list[str] = []
+        original_mark = db.mark_l0_stale
+        original_update = db.update_dispatch_state
+
+        def tracked_mark():
+            call_order.append("mark_l0_stale")
+            return original_mark()
+
+        def tracked_update(did, state, **kwargs):
+            call_order.append(f"update_{state}")
+            return original_update(did, state, **kwargs)
+
+        with patch.object(dispatcher, "_execute_and_validate", return_value=True), \
+             patch("engram.server.dispatcher.next_chunk") as mock_nc, \
+             patch.object(db, "mark_l0_stale", side_effect=tracked_mark), \
+             patch.object(db, "update_dispatch_state", side_effect=tracked_update):
+            mock_chunk = MagicMock()
+            mock_chunk.chunk_id = 1
+            mock_nc.return_value = mock_chunk
+            dispatcher.dispatch()
+
+        # Verify ordering: validated → stale → committed
+        assert "mark_l0_stale" in call_order
+        assert "update_committed" in call_order
+        stale_idx = call_order.index("mark_l0_stale")
+        committed_idx = call_order.index("update_committed")
+        assert stale_idx < committed_idx
+
+    def test_recovery_validated_stale_before_committed(self, project: Path, config: dict) -> None:
+        """Recovery of validated dispatch: stale before committed."""
+        from engram.server.dispatcher import Dispatcher
+
+        db = ServerDB(project / ".engram" / "engram.db")
+        dispatcher = Dispatcher(config, project, db)
+
+        did = db.create_dispatch(chunk_id=1)
+        db.update_dispatch_state(did, "dispatched")
+        db.update_dispatch_state(did, "validated")
+        dispatch = db.get_dispatch(did)
+
+        call_order: list[str] = []
+        original_mark = db.mark_l0_stale
+        original_update = db.update_dispatch_state
+
+        def tracked_mark():
+            call_order.append("mark_l0_stale")
+            return original_mark()
+
+        def tracked_update(did, state, **kwargs):
+            call_order.append(f"update_{state}")
+            return original_update(did, state, **kwargs)
+
+        with patch.object(db, "mark_l0_stale", side_effect=tracked_mark), \
+             patch.object(db, "update_dispatch_state", side_effect=tracked_update):
+            dispatcher.recover_dispatch(dispatch)
+
+        stale_idx = call_order.index("mark_l0_stale")
+        committed_idx = call_order.index("update_committed")
+        assert stale_idx < committed_idx
+
+
+# ==================================================================
+# Dispatcher recovery uses mark_l0_stale
+# ==================================================================
+
+
+class TestRecoveryMarksStale:
+    def test_recover_validated_marks_stale(self, project: Path, config: dict) -> None:
+        """Validated recovery marks L0 stale and transitions to committed."""
+        from engram.server.dispatcher import Dispatcher
+
+        db = ServerDB(project / ".engram" / "engram.db")
+        dispatcher = Dispatcher(config, project, db)
+
+        did = db.create_dispatch(chunk_id=1)
+        db.update_dispatch_state(did, "dispatched")
+        db.update_dispatch_state(did, "validated")
+        dispatch = db.get_dispatch(did)
+
+        result = dispatcher.recover_dispatch(dispatch)
+
+        assert result is True
+        assert db.is_l0_stale() is True
+        final = db.get_dispatch(did)
+        assert final["state"] == "committed"
+
+    def test_recover_dispatched_lint_pass_marks_stale(self, project: Path, config: dict) -> None:
+        """Dispatched recovery with passing lint marks L0 stale."""
+        from engram.server.dispatcher import Dispatcher
+
+        db = ServerDB(project / ".engram" / "engram.db")
+        dispatcher = Dispatcher(config, project, db)
+
+        chunks_dir = project / ".engram" / "chunks"
+        chunks_dir.mkdir(parents=True)
+        input_path = chunks_dir / "chunk_001_input.md"
+        input_path.write_text("test input")
+
+        did = db.create_dispatch(chunk_id=1, input_path=str(input_path))
+        db.update_dispatch_state(did, "dispatched")
+        dispatch = db.get_dispatch(did)
+
+        result = dispatcher.recover_dispatch(dispatch)
+
+        assert result is True
+        assert db.is_l0_stale() is True
+        final = db.get_dispatch(did)
+        assert final["state"] == "committed"
+
+
+# ==================================================================
+# Bootstrap fold: L0 regen after all chunks
+# ==================================================================
+
+
+class TestForwardFoldL0:
+    @patch("engram.bootstrap.fold.regenerate_l0_briefing")
+    @patch("engram.bootstrap.fold._dispatch_and_validate")
+    @patch("engram.bootstrap.fold.next_chunk")
+    @patch("engram.bootstrap.fold.build_queue")
+    def test_l0_regen_after_all_chunks(
+        self,
+        mock_bq: MagicMock,
+        mock_nc: MagicMock,
+        mock_dv: MagicMock,
+        mock_regen: MagicMock,
+        project: Path,
+    ) -> None:
+        """L0 briefing regenerated exactly once after all chunks complete."""
+        from engram.bootstrap.fold import forward_fold
+        from datetime import date
+
+        mock_bq.return_value = [
+            {"date": "2026-02-01T00:00:00Z", "type": "doc", "path": "x.md", "chars": 100},
+        ]
+
+        chunk1 = MagicMock(chunk_id=1, chunk_type="fold", items_count=1,
+                           date_range="2026-02-01 to 2026-02-01",
+                           pre_assigned_ids={}, chunk_chars=100)
+        chunk2 = MagicMock(chunk_id=2, chunk_type="fold", items_count=1,
+                           date_range="2026-02-02 to 2026-02-02",
+                           pre_assigned_ids={}, chunk_chars=100)
+        mock_nc.side_effect = [chunk1, chunk2, ValueError("Queue is empty")]
+        mock_dv.return_value = True
+        mock_regen.return_value = True
+
+        result = forward_fold(project, date(2026, 1, 1))
+        assert result is True
+        # L0 regen called exactly once at the end, not per-chunk
+        mock_regen.assert_called_once()
+
+    @patch("engram.bootstrap.fold.regenerate_l0_briefing")
+    @patch("engram.bootstrap.fold._dispatch_and_validate")
+    @patch("engram.bootstrap.fold.next_chunk")
+    @patch("engram.bootstrap.fold.build_queue")
+    def test_no_l0_regen_on_empty_queue(
+        self,
+        mock_bq: MagicMock,
+        mock_nc: MagicMock,
+        mock_dv: MagicMock,
+        mock_regen: MagicMock,
+        project: Path,
+    ) -> None:
+        """No L0 regen when queue is empty (no chunks processed)."""
+        from engram.bootstrap.fold import forward_fold
+        from datetime import date
+
+        mock_bq.return_value = []
+        result = forward_fold(project, date(2026, 1, 1))
+        assert result is True
+        mock_regen.assert_not_called()
+
+    @patch("engram.bootstrap.fold.regenerate_l0_briefing")
+    @patch("engram.bootstrap.fold._dispatch_and_validate")
+    @patch("engram.bootstrap.fold.next_chunk")
+    @patch("engram.bootstrap.fold.build_queue")
+    def test_no_l0_regen_on_failure(
+        self,
+        mock_bq: MagicMock,
+        mock_nc: MagicMock,
+        mock_dv: MagicMock,
+        mock_regen: MagicMock,
+        project: Path,
+    ) -> None:
+        """No L0 regen when chunks fail."""
+        from engram.bootstrap.fold import forward_fold
+        from datetime import date
+
+        mock_bq.return_value = [
+            {"date": "2026-02-01T00:00:00Z", "type": "doc", "path": "x.md", "chars": 100},
+        ]
+        chunk = MagicMock(chunk_id=1, chunk_type="fold", items_count=1,
+                          date_range="2026-02-01 to 2026-02-01",
+                          pre_assigned_ids={}, chunk_chars=100)
+        mock_nc.side_effect = [chunk, ValueError("Queue is empty")]
+        mock_dv.return_value = False
+
+        result = forward_fold(project, date(2026, 1, 1))
+        assert result is False
+        mock_regen.assert_not_called()
+
+
+# ==================================================================
+# Bootstrap seed: L0 regen after dispatch succeeds
+# ==================================================================
+
+
+class TestSeedL0:
+    @patch("engram.bootstrap.seed.regenerate_l0_briefing")
+    @patch("engram.bootstrap.seed._dispatch_seed_agent")
+    def test_seed_regens_l0(self, mock_dispatch: MagicMock, mock_regen: MagicMock, project: Path) -> None:
+        """Seed regenerates L0 briefing after successful dispatch."""
+        from engram.bootstrap.seed import seed
+
+        mock_dispatch.return_value = True
+        mock_regen.return_value = True
+
+        result = seed(project, from_date=None)
+        assert result is True
+        mock_regen.assert_called_once()
+
+    @patch("engram.bootstrap.seed.regenerate_l0_briefing")
+    @patch("engram.bootstrap.seed._dispatch_seed_agent")
+    def test_seed_no_l0_on_failure(self, mock_dispatch: MagicMock, mock_regen: MagicMock, project: Path) -> None:
+        """Seed does NOT regen L0 when dispatch fails."""
+        from engram.bootstrap.seed import seed
+
+        mock_dispatch.return_value = False
+
+        result = seed(project, from_date=None)
+        assert result is False
+        mock_regen.assert_not_called()
+
+
+# ==================================================================
+# Briefing module: regenerate_l0_briefing
+# ==================================================================
+
+
+class TestRegenerateL0Briefing:
+    def test_returns_false_no_target(self, project: Path, config: dict) -> None:
+        """Returns False when target file doesn't exist."""
+        from engram.server.briefing import regenerate_l0_briefing
+        from engram.config import resolve_doc_paths
+
+        config["briefing"] = {"file": "NONEXISTENT.md", "section": "## Briefing"}
+        doc_paths = resolve_doc_paths(config, project)
+        assert regenerate_l0_briefing(config, project, doc_paths) is False
+
+    @patch("engram.server.briefing._generate_briefing", return_value="Test briefing")
+    def test_injects_briefing(self, mock_gen: MagicMock, project: Path, config: dict) -> None:
+        """Successful regen injects briefing into CLAUDE.md."""
+        from engram.server.briefing import regenerate_l0_briefing
+        from engram.config import resolve_doc_paths
+
+        target = project / "CLAUDE.md"
+        target.write_text("# Project\n\nExisting content.\n")
+
+        doc_paths = resolve_doc_paths(config, project)
+        result = regenerate_l0_briefing(config, project, doc_paths)
+        assert result is True
+        text = target.read_text()
+        assert "Test briefing" in text
+
+    @patch("engram.server.briefing._generate_briefing", return_value=None)
+    def test_returns_false_on_generation_failure(self, mock_gen: MagicMock, project: Path, config: dict) -> None:
+        from engram.server.briefing import regenerate_l0_briefing
+        from engram.config import resolve_doc_paths
+
+        target = project / "CLAUDE.md"
+        target.write_text("# Project\n")
+
+        doc_paths = resolve_doc_paths(config, project)
+        assert regenerate_l0_briefing(config, project, doc_paths) is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -625,7 +625,7 @@ class TestDispatcherHelpers:
         assert "# Concept Registry" in contents["concepts"]
 
     def test_inject_section_new(self, tmp_path: Path) -> None:
-        from engram.server.dispatcher import _inject_section
+        from engram.server.briefing import _inject_section
 
         f = tmp_path / "test.md"
         f.write_text("# Existing\nContent here.\n")
@@ -637,7 +637,7 @@ class TestDispatcherHelpers:
         assert "# Existing" in text
 
     def test_inject_section_replace(self, tmp_path: Path) -> None:
-        from engram.server.dispatcher import _inject_section
+        from engram.server.briefing import _inject_section
 
         f = tmp_path / "test.md"
         f.write_text(


### PR DESCRIPTION
## Summary

- Extracts `regenerate_l0_briefing()` to standalone `engram/server/briefing.py` so bootstrap paths don't need to instantiate a Dispatcher
- Adds `l0_stale` column to `server_state` with idempotent migration, plus `mark_l0_stale()`, `clear_l0_stale()`, `is_l0_stale()` DB methods
- Replaces all L0 regen in `Dispatcher.dispatch()` and all 3 `recover_dispatch()` paths with `mark_l0_stale()` (ordering invariant: stale BEFORE committed)
- Adds `queue_is_empty()` drain predicate to `chunker.py`
- Server loop: startup L0 check + unconditional main-loop L0 check (queue-drain triggered)
- Bootstrap `fold.py`: L0 regen once after all chunks complete (not per-chunk)
- Bootstrap `seed.py`: L0 regen after seed dispatch succeeds
- Updates `engram_idea.md` dispatch mechanics, crash recovery, and Tiered Retrieval sections

## Spec Reference

`specs/24_l0_briefing_on_queue_drain.md`

## Test Plan

- [x] 446 existing tests pass (no regressions)
- [x] New `test_l0_drain.py`: DB l0_stale methods, queue_is_empty, dispatcher marks stale, crash-window ordering, bootstrap fold/seed L0 regen, briefing module
- [x] Updated `test_server.py` recovery tests for mark_l0_stale (no more _regenerate_l0_briefing mock)

Fixes #24