### PR TITLE
Deduplicate _resolve_ref_commit and ServerDB instantiation

### DIFF
--- a/engram/bootstrap/fold.py
+++ b/engram/bootstrap/fold.py
@@ -140,9 +140,10 @@ def forward_fold(
     remaining = len(entries)
     log.info("Queue built: %d entries from %s forward", remaining, from_date)
 
+    db = ServerDB(project_root / ".engram" / "engram.db")
+
     if remaining == 0:
         log.info("No entries to process after %s", from_date)
-        db = ServerDB(project_root / ".engram" / "engram.db")
         db.clear_fold_from()
         return True
 
@@ -187,7 +188,6 @@ def forward_fold(
         doc_paths = resolve_doc_paths(config, project_root)
         regenerate_l0_briefing(config, project_root, doc_paths)
 
-    db = ServerDB(project_root / ".engram" / "engram.db")
     db.clear_fold_from()
     log.info("Forward fold completed successfully (%d chunks)", chunk_count)
     return True


### PR DESCRIPTION
## Summary

- **chunker.py**: Added `ref_commit` field to `DriftReport` so `scan_drift()` exposes the resolved commit. `next_chunk()` now reads `drift.ref_commit` instead of calling `_resolve_ref_commit()` a second time (eliminating a redundant `git log` subprocess call).
- **fold.py**: Hoisted `ServerDB` instantiation above the early-return check in `forward_fold()` so both the empty-queue and normal-completion paths share a single instance.

## Test Plan
- [x] All 446 tests pass (`python -m pytest tests/ -v`)
- [x] No behavioral changes — purely mechanical deduplication

Fixes #28