### PR TITLE
Add lint step and EVOLVED heading format to fold agent prompt

### DIFF
--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -457,6 +457,7 @@ def next_chunk(
             doc_paths=doc_paths,
             ref_commit=ref_commit,
             ref_date=fold_from,
+            project_root=project_root,
         )
 
         input_path = chunks_dir / f"chunk_{chunk_id:03d}_input.md"

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -467,6 +467,7 @@ def next_chunk(
             date_range=drift_type,
             input_path=input_path,
             doc_paths=doc_paths,
+            project_root=project_root,
         )
         prompt_path = chunks_dir / f"chunk_{chunk_id:03d}_prompt.txt"
         prompt_path.write_text(prompt_content)
@@ -566,6 +567,7 @@ def next_chunk(
         date_range=date_range,
         input_path=input_path,
         doc_paths=doc_paths,
+        project_root=project_root,
     )
     prompt_path = chunks_dir / f"chunk_{chunk_id:03d}_prompt.txt"
     prompt_path.write_text(prompt_content)

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -74,6 +74,7 @@ def render_triage_input(
     doc_paths: dict[str, Path],
     ref_commit: str | None = None,
     ref_date: str | None = None,
+    project_root: Path | None = None,
 ) -> str:
     """Render a drift-triage chunk's input.md file.
 
@@ -95,6 +96,12 @@ def render_triage_input(
     else:
         entries = []
 
+    lint_cmd = (
+        f'engram lint --project-root "{project_root.resolve()}"'
+        if project_root
+        else "engram lint --project-root <project_root>"
+    )
+
     return template.render(
         drift_type=drift_type,
         entries=entries,
@@ -103,6 +110,7 @@ def render_triage_input(
         entry_count=len(entries),
         ref_commit=ref_commit,
         ref_date=ref_date,
+        lint_cmd=lint_cmd,
     )
 
 
@@ -128,7 +136,7 @@ def render_agent_prompt(
     ])
 
     lint_cmd = (
-        f"engram lint --project-root {project_root.resolve()}"
+        f'engram lint --project-root "{project_root.resolve()}"'
         if project_root
         else "engram lint --project-root <project_root>"
     )

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -112,6 +112,7 @@ def render_agent_prompt(
     date_range: str,
     input_path: Path,
     doc_paths: dict[str, Path],
+    project_root: Path | None = None,
 ) -> str:
     """Render the chunk_NNN_prompt.txt agent execution prompt.
 
@@ -125,6 +126,12 @@ def render_agent_prompt(
         f"- {doc_paths['concept_graveyard']}",
         f"- {doc_paths['epistemic_graveyard']}",
     ])
+
+    lint_cmd = (
+        f"engram lint --project-root {project_root.resolve()}"
+        if project_root
+        else "engram lint --project-root <project_root>"
+    )
 
     return (
         f"You are processing a knowledge fold chunk.\n"
@@ -153,6 +160,13 @@ def render_agent_prompt(
         f"- DEAD/refuted entries: 1-2 sentences max. Key lesson + what replaced it.\n"
         f"- Process ALL items in the chunk\n"
         f"- Use ONLY pre-assigned IDs for new entries (listed in the input file)\n"
+        f"\n"
+        f"After All Edits: Lint Check (Required)\n"
+        f"\n"
+        f"Run the linter after completing all edits:\n"
+        f"  {lint_cmd}\n"
+        f"Fix every violation reported. Re-run until lint passes with 0 violations.\n"
+        f"Do not stop until lint is clean.\n"
     )
 
 

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -127,7 +127,7 @@ For each cluster of related workflows:
 
 Run the linter after completing all edits:
 ```
-engram lint --project-root <project_root>
+{{ lint_cmd }}
 ```
 Fix every violation reported. Re-run until lint passes with 0 violations.
 Do not stop until lint is clean.

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -29,8 +29,10 @@ is never a valid reason to skip triage. For each one:
 - Mark **DEAD** if the concept was abandoned/replaced.
   Use 1-2 sentences: what replaced it + key lesson.
   Move the full entry to {{ doc_paths.concept_graveyard }}, replace with STUB.
-- Mark **EVOLVED → new_name** if it was renamed/restructured.
-  Update the Code: field to point to the new location.
+- Mark **EVOLVED** if it was renamed/restructured.
+  Change the heading to: `## C{NNN}: name (EVOLVED) → new_name` (arrow OUTSIDE parens).
+  Update the Code: field to point to the new location. Keep the body in place.
+  Do NOT move EVOLVED entries to the graveyard — graveyard is for DEAD only.
   (Common renames: .ts→.tsx, ground_truth_annotator/→replay_server/)
 - Leave ACTIVE only if the files are genuinely expected to be created later.
 
@@ -120,3 +122,12 @@ For each cluster of related workflows:
 - Be succinct. DEAD/refuted entries: 1-2 sentences max.
 - When moving entries to graveyard, append the full content there, then replace
   the living doc entry with a STUB (heading + arrow pointer only).
+
+## After All Edits: Lint Check (Required)
+
+Run the linter after completing all edits:
+```
+engram lint --project-root <project_root>
+```
+Fix every violation reported. Re-run until lint passes with 0 violations.
+Do not stop until lint is clean.


### PR DESCRIPTION
## Summary

- Clarifies EVOLVED heading format in `triage_prompt.md`: arrow goes outside parens (`(EVOLVED) → target`), body stays in the living doc, graveyard is for DEAD only
- Adds a mandatory post-edit lint step to both `triage_prompt.md` and `render_agent_prompt()`: agent must run `engram lint`, fix all violations, and re-run until clean before stopping
- Passes `project_root` through to `render_agent_prompt()` so the lint command in the prompt contains the resolved path

## Why

Without this, fold agents produce malformed EVOLVED headings (lint violations) and stop without checking. In server mode there is no human to catch this.

## Test Plan
- [x] All 446 existing tests pass
- [x] Prompt output verified to include lint step with resolved project_root path

Fixes #32