### PR TITLE
budget: tighten defaults — overhead 10K→100K, max_chunk 200K→80K

### DIFF
--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -328,8 +328,8 @@ def compute_budget(config: dict, doc_paths: dict[str, Path]) -> tuple[int, int]:
     """
     budget_cfg = config.get("budget", {})
     context_limit = budget_cfg.get("context_limit_chars", 600_000)
-    overhead = budget_cfg.get("instructions_overhead", 10_000)
-    max_chunk = budget_cfg.get("max_chunk_chars", 200_000)
+    overhead = budget_cfg.get("instructions_overhead", 100_000)
+    max_chunk = budget_cfg.get("max_chunk_chars", 80_000)
 
     living_doc_keys = ["timeline", "concepts", "epistemic", "workflows"]
     living_docs_chars = 0


### PR DESCRIPTION
## Summary

Fold agents were compacting before making a single edit. Root cause: both budget defaults were wrong.

## Evidence

Empirical data from fractal-market-simulator:
- Chunk 002: 440K chars file reads → 10% from compact, 0 edits made
- Chunk 003: 453K chars file reads → 8% from compact, 0 edits made

Actual chars/token ratio: ~2.5 (450K chars = 92% of 200K token context).

## Root Cause

| Default | Old | Problem |
|---------|-----|---------|
| `instructions_overhead` | 10,000 | Real overhead is ~100K chars (system prompt + tools + CLAUDE.md) |
| `max_chunk_chars` | 200,000 | Living docs (257K) + chunk (196K) + overhead = 453K chars = 181K tokens, no room for edits |

## Fix

| Default | Old | New |
|---------|-----|-----|
| `instructions_overhead` | 10,000 | 100,000 |
| `max_chunk_chars` | 200,000 | 80,000 |

New budget for fractal-market-simulator:
`min(600K - 257K - 100K, 80K) = 80K chars`

Total file reads: 337K chars / 2.5 = **135K tokens**
Remaining for edits: ~65K tokens ✓

## Test Plan
- [ ] Existing tests pass
- [ ] Next fold chunk produces budget ≤ 80K chars
- [ ] Agent completes without compacting

Fixes #36