### PR TITLE
compact: remove dead entries entirely instead of leaving stubs

### DIFF
--- a/engram/compact/graveyard.py
+++ b/engram/compact/graveyard.py
@@ -209,17 +209,15 @@ def compact_living_doc(
 
     for sec in sections:
         if is_stub(sec["heading"]):
-            # Already a stub — keep as-is
-            parts.append(sec["text"])
+            # Already in graveyard — remove entirely from living doc
+            chars_saved += len(sec["text"])
             continue
 
         status = sec.get("status")
         if status in eligible_statuses:
-            # Move to graveyard — add trailing blank line to maintain
-            # valid markdown structure between sections
-            stub = move_to_graveyard(sec, doc_type, graveyard_path)
-            parts.append(stub + "\n")
-            chars_saved += len(sec["text"]) - len(stub) - 1
+            # Move to graveyard — remove entirely from living doc (no stub)
+            move_to_graveyard(sec, doc_type, graveyard_path)
+            chars_saved += len(sec["text"])
         else:
             # Keep full text
             parts.append(sec["text"])

--- a/tests/test_graveyard.py
+++ b/tests/test_graveyard.py
@@ -254,17 +254,13 @@ class TestCompactLivingDoc:
         new_content, chars_saved = compact_living_doc(content, "concepts", gy_path)
 
         assert chars_saved > 0
-        # STUB replaces the dead entry
-        assert "C042" in new_content
-        assert "\u2192 concept_graveyard.md#C042" in new_content
+        # Dead entry removed entirely — no stub, no content
+        assert "C042" not in new_content
+        assert "No longer needed" not in new_content
         # Active entries preserved
         assert "src/active.py" in new_content
         assert "src/another.py" in new_content
-        # Blank line separator preserved between STUB and next section
-        assert "\n\n## C050:" in new_content
-        # Dead entry's full content NOT in living doc
-        assert "No longer needed" not in new_content
-        # But IS in graveyard
+        # Full content IS in graveyard
         gy_content = gy_path.read_text()
         assert "No longer needed" in gy_content
 
@@ -281,9 +277,10 @@ class TestCompactLivingDoc:
 
         new_content, chars_saved = compact_living_doc(content, "concepts", gy_path)
 
-        assert chars_saved == 0
-        assert "C001" in new_content
-        # Graveyard not written to
+        # Existing stub removed entirely — chars saved
+        assert chars_saved > 0
+        assert "C001" not in new_content
+        # Graveyard not written to (stub was already there, no new append)
         assert not gy_path.exists()
 
     def test_compacts_epistemic_refuted(self, tmp_path: Path):
@@ -302,9 +299,11 @@ class TestCompactLivingDoc:
         new_content, chars_saved = compact_living_doc(content, "epistemic", gy_path)
 
         assert chars_saved > 0
-        assert "\u2192 epistemic_graveyard.md#E007" in new_content
-        assert "Strong evidence" in new_content
+        # Refuted entry removed entirely — no stub
+        assert "E007" not in new_content
         assert "Backtesting showed otherwise" not in new_content
+        # Believed entry preserved
+        assert "Strong evidence" in new_content
 
     def test_no_eligible_entries(self, tmp_path: Path):
         gy_path = tmp_path / "concept_graveyard.md"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -328,12 +328,10 @@ class TestGraveyardBootstrapping:
 """
         result, _ = compact_living_doc(content, "concepts", gy_path)
 
-        # Living doc should have stub
+        # Living doc should have no entry for proximity_pruning (removed entirely)
         sections = parse_sections(result)
         dead_sec = [s for s in sections if "proximity_pruning" in s["heading"]]
-        assert len(dead_sec) == 1
-        assert is_stub(dead_sec[0]["heading"])
-        assert "\u2192" in dead_sec[0]["heading"]
+        assert len(dead_sec) == 0
 
         # Graveyard should have full entry
         gy_content = gy_path.read_text()
@@ -373,10 +371,11 @@ class TestGraveyardBootstrapping:
         result, _ = compact_living_doc(content, "epistemic", gy_path)
 
         sections = parse_sections(result)
+        # Refuted entry removed entirely
         refuted = [s for s in sections if "74_percent" in s["heading"]]
-        assert len(refuted) == 1
-        assert is_stub(refuted[0]["heading"])
+        assert len(refuted) == 0
 
+        # Unverified entry preserved
         unverified = [s for s in sections if "tick_level" in s["heading"]]
         assert len(unverified) == 1
         assert not is_stub(unverified[0]["heading"])
@@ -515,9 +514,9 @@ class TestMigrate:
         concepts = (project / "docs" / "concept_registry.md").read_text()
         sections = parse_sections(concepts)
 
+        # Dead entry removed entirely from living doc
         dead = [s for s in sections if "proximity_pruning" in s["heading"]]
-        assert len(dead) == 1
-        assert is_stub(dead[0]["heading"])
+        assert len(dead) == 0
 
     def test_active_entries_preserved(self, tmp_path):
         project = _create_project(tmp_path)


### PR DESCRIPTION
## Summary

Dead/refuted entries now disappear from living docs after compaction — no stub left behind. The graveyard is the canonical record; a one-liner pointer in the registry adds no lookup value.

## Measurement

fractal-market-simulator concept_registry:
- 139 stub lines = **7,441 chars = 12% of registry**
- ~3,200 tokens freed per fold agent read
- Compounds with every chunk

## Behaviour

| Before | After |
|--------|-------|
| `## C042: name (DEAD) → concept_graveyard.md#C042` left in registry | Entry removed entirely |
| Existing stubs kept on re-compact | Existing stubs also removed |
| `chars_saved = len(full) - len(stub)` | `chars_saved = len(full)` |

Graveyard append is unchanged — full entry still archived there.

## Tests

6 tests updated to expect removal rather than stub presence. 446 pass.

Fixes #38