### PR TITLE
feat: add epistemic_audit drift type

### DIFF
--- a/engram/cli.py
+++ b/engram/cli.py
@@ -81,6 +81,7 @@ thresholds:
   orphan_triage: 50
   contested_review_days: 14
   stale_unverified_days: 30
+  stale_epistemic_days: 90
   workflow_repetition: 3
 
 budget:

--- a/engram/config.py
+++ b/engram/config.py
@@ -37,6 +37,7 @@ DEFAULTS: dict[str, Any] = {
         "orphan_triage": 50,
         "contested_review_days": 14,
         "stale_unverified_days": 30,
+        "stale_epistemic_days": 90,
         "workflow_repetition": 3,
     },
     "budget": {

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -237,10 +237,11 @@ def _extract_latest_history_date(section_text: str) -> datetime | None:
 
     for line in section_text.splitlines():
         stripped = line.strip()
+        normalized = stripped.removeprefix("- ").strip()
 
-        if stripped.startswith("**History:**"):
+        if normalized.startswith("**History:**"):
             in_history = True
-            remainder = stripped[len("**History:**"):].strip()
+            remainder = normalized[len("**History:**"):].strip()
             if remainder:
                 history_lines.append(remainder)
             continue
@@ -251,7 +252,7 @@ def _extract_latest_history_date(section_text: str) -> datetime | None:
         if stripped.startswith("## "):
             break
         # Stop at the next top-level epistemic field (e.g. **Agent guidance:** ...).
-        if re.match(r"^\*\*[^*]+:\*\*(?:\s.*)?$", stripped):
+        if re.match(r"^\*\*[^*]+:\*\*(?:\s.*)?$", normalized):
             break
 
         if stripped:

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -237,11 +237,10 @@ def _extract_latest_history_date(section_text: str) -> datetime | None:
 
     for line in section_text.splitlines():
         stripped = line.strip()
-        normalized = stripped.removeprefix("- ").strip()
 
-        if normalized.startswith("**History:**"):
+        if stripped.startswith("**History:**"):
             in_history = True
-            remainder = normalized[len("**History:**"):].strip()
+            remainder = stripped[len("**History:**"):].strip()
             if remainder:
                 history_lines.append(remainder)
             continue
@@ -251,7 +250,8 @@ def _extract_latest_history_date(section_text: str) -> datetime | None:
 
         if stripped.startswith("## "):
             break
-        if normalized.startswith("**") and normalized.endswith(":"):
+        # Stop at the next top-level epistemic field (e.g. **Agent guidance:** ...).
+        if re.match(r"^\*\*[^*]+:\*\*(?:\s.*)?$", stripped):
             break
 
         if stripped:

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -306,7 +306,11 @@ def _read_queue_entry_text(project_root: Path, item: dict[str, Any]) -> str:
         if item.get("type") == "issue":
             from engram.fold.sources import render_issue_markdown
             issue_data = json.loads(item_path.read_text())
-            return render_issue_markdown(issue_data)
+            rendered = render_issue_markdown(issue_data)
+            issue_title = issue_data.get("title") or item.get("issue_title")
+            if isinstance(issue_title, str) and issue_title.strip():
+                return f"{issue_title.strip()}\n\n{rendered}"
+            return rendered
         return item_path.read_text(errors="ignore")
     except (FileNotFoundError, OSError, json.JSONDecodeError):
         return ""

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -31,6 +31,7 @@ class DriftReport:
     """Results from scanning living docs for drift conditions."""
 
     orphaned_concepts: list[dict] = field(default_factory=list)
+    epistemic_audit: list[dict] = field(default_factory=list)
     contested_claims: list[dict] = field(default_factory=list)
     stale_unverified: list[dict] = field(default_factory=list)
     workflow_repetitions: list[dict] = field(default_factory=list)
@@ -39,11 +40,14 @@ class DriftReport:
     def triggered(self, thresholds: dict) -> str | None:
         """Return the highest-priority drift type that exceeds its threshold.
 
-        Priority order: orphans > contested > stale_unverified > workflow.
+        Priority order:
+        orphans > epistemic_audit > contested > stale_unverified > workflow.
         Returns None if no threshold is exceeded.
         """
         if len(self.orphaned_concepts) > thresholds.get("orphan_triage", 50):
             return "orphan_triage"
+        if len(self.epistemic_audit) > thresholds.get("epistemic_audit", 0):
+            return "epistemic_audit"
         if len(self.contested_claims) > thresholds.get("contested_review", 5):
             return "contested_review"
         if len(self.stale_unverified) > thresholds.get("stale_unverified", 10):
@@ -60,7 +64,7 @@ class ChunkResult:
     chunk_id: int
     input_path: Path
     prompt_path: Path
-    chunk_type: str  # "fold" | "orphan_triage" | "contested_review" | ...
+    chunk_type: str  # "fold" | "orphan_triage" | "epistemic_audit" | ...
     items_count: int
     chunk_chars: int
     budget: int
@@ -226,6 +230,102 @@ def _extract_latest_date(text: str) -> datetime | None:
     return max(parsed) if parsed else None
 
 
+def _extract_latest_history_date(section_text: str) -> datetime | None:
+    """Extract the most recent YYYY-MM-DD date from an epistemic History block."""
+    history_lines: list[str] = []
+    in_history = False
+
+    for line in section_text.splitlines():
+        stripped = line.strip()
+        normalized = stripped.removeprefix("- ").strip()
+
+        if normalized.startswith("**History:**"):
+            in_history = True
+            remainder = normalized[len("**History:**"):].strip()
+            if remainder:
+                history_lines.append(remainder)
+            continue
+
+        if not in_history:
+            continue
+
+        if stripped.startswith("## "):
+            break
+        if normalized.startswith("**") and normalized.endswith(":"):
+            break
+
+        if stripped:
+            history_lines.append(stripped)
+
+    if not history_lines:
+        return None
+
+    return _extract_latest_date("\n".join(history_lines))
+
+
+def _parse_queue_date(raw: Any) -> datetime | None:
+    """Parse a queue entry date into timezone-aware UTC datetime."""
+    if not isinstance(raw, str):
+        return None
+    value = raw.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        try:
+            parsed = datetime.strptime(value[:10], "%Y-%m-%d")
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _extract_epistemic_subject(heading: str) -> str | None:
+    """Extract an epistemic entry subject from heading text."""
+    match = re.match(r"^##\s+E\d{3,}:\s+(.+)$", heading.strip())
+    if not match:
+        return None
+    subject = match.group(1)
+    subject = re.sub(r"\s+\([^)]*\)\s*(?:→\s+\S+)?\s*$", "", subject).strip()
+    return subject or None
+
+
+def _read_queue_entry_text(project_root: Path, item: dict[str, Any]) -> str:
+    """Read queue entry text for subject-reference matching."""
+    rel_path = item.get("path")
+    if not isinstance(rel_path, str):
+        return ""
+
+    item_path = project_root / rel_path
+    try:
+        if item.get("type") == "issue":
+            from engram.fold.sources import render_issue_markdown
+            issue_data = json.loads(item_path.read_text())
+            return render_issue_markdown(issue_data)
+        return item_path.read_text(errors="ignore")
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return ""
+
+
+def _read_queue_entries(queue_file: Path) -> list[dict[str, Any]]:
+    """Load queue.jsonl entries, skipping malformed lines."""
+    if not queue_file.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    with open(queue_file) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(entry, dict):
+                entries.append(entry)
+    return entries
+
+
 def _find_claims_by_status(
     epistemic_path: Path, status: str, days_threshold: int,
 ) -> list[dict]:
@@ -251,6 +351,74 @@ def _find_claims_by_status(
                 "days_old": age_days,
                 "last_date": latest.strftime("%Y-%m-%d"),
             })
+    return results
+
+
+def _find_stale_epistemic_entries(
+    epistemic_path: Path,
+    *,
+    days_threshold: int,
+    project_root: Path | None = None,
+    queue_entries: list[dict[str, Any]] | None = None,
+) -> list[dict]:
+    """Find stale believed/unverified epistemic entries for audit.
+
+    An entry is stale when:
+    - status is believed or unverified
+    - age since latest History date exceeds days_threshold
+    - no queue item references the entry subject after that history date
+    """
+    if not epistemic_path.exists():
+        return []
+
+    searchable_queue: list[tuple[datetime, str]] = []
+    if project_root and queue_entries:
+        for item in queue_entries:
+            queued_at = _parse_queue_date(item.get("date"))
+            if queued_at is None:
+                continue
+            text = _read_queue_entry_text(project_root, item)
+            if text:
+                searchable_queue.append((queued_at, text.lower()))
+
+    sections = parse_sections(epistemic_path.read_text())
+    now = datetime.now(timezone.utc)
+    results: list[dict] = []
+
+    for sec in sections:
+        if sec["status"] not in {"believed", "unverified"}:
+            continue
+        if is_stub(sec["heading"]):
+            continue
+
+        latest_history = _extract_latest_history_date(sec["text"])
+        if latest_history is None:
+            continue
+
+        age_days = (now - latest_history).days
+        if age_days <= days_threshold:
+            continue
+
+        subject = _extract_epistemic_subject(sec["heading"])
+        subject_lower = subject.lower() if subject else None
+        was_referenced = bool(
+            subject_lower and any(
+                queued_at > latest_history and subject_lower in queue_text
+                for queued_at, queue_text in searchable_queue
+            )
+        )
+        if was_referenced:
+            continue
+
+        results.append({
+            "name": sec["heading"].lstrip("#").strip(),
+            "id": extract_id(sec["heading"]),
+            "subject": subject,
+            "status": sec["status"],
+            "days_old": age_days,
+            "last_date": latest_history.strftime("%Y-%m-%d"),
+        })
+
     return results
 
 
@@ -318,6 +486,7 @@ def scan_drift(
     """
     paths = resolve_doc_paths(config, project_root)
     thresholds = config.get("thresholds", {})
+    queue_entries = _read_queue_entries(project_root / ".engram" / "queue.jsonl")
 
     ref_commit: str | None = None
     if fold_from:
@@ -332,6 +501,12 @@ def scan_drift(
     return DriftReport(
         orphaned_concepts=_find_orphaned_concepts(
             paths["concepts"], project_root, ref_commit=ref_commit,
+        ),
+        epistemic_audit=_find_stale_epistemic_entries(
+            paths["epistemic"],
+            days_threshold=thresholds.get("stale_epistemic_days", 90),
+            project_root=project_root,
+            queue_entries=queue_entries,
         ),
         contested_claims=_find_claims_by_status(
             paths["epistemic"], "contested",
@@ -520,6 +695,7 @@ def next_chunk(
         # Count drift entries for reporting
         drift_counts = {
             "orphan_triage": len(drift.orphaned_concepts),
+            "epistemic_audit": len(drift.epistemic_audit),
             "contested_review": len(drift.contested_claims),
             "stale_unverified": len(drift.stale_unverified),
             "workflow_synthesis": len(drift.workflow_repetitions),

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -87,6 +87,8 @@ def render_triage_input(
 
     if drift_type == "orphan_triage":
         entries = drift_report.orphaned_concepts
+    elif drift_type == "epistemic_audit":
+        entries = drift_report.epistemic_audit
     elif drift_type == "contested_review":
         entries = drift_report.contested_claims
     elif drift_type == "stale_unverified":

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -64,6 +64,23 @@ rename when it reaches that date in the queue.
 {% endif %}
 
 **Goal: get orphan count to 0.** Every entry must be resolved.
+{% elif drift_type == "epistemic_audit" %}
+# Epistemic Audit Round (Chunk {{ chunk_id }})
+
+This is a dedicated review round for stale epistemic entries.
+These entries are marked believed/unverified, older than the audit threshold,
+and have not been referenced by recent queue items.
+
+For each entry below:
+- **Confirm** if still valid. Keep status and add a fresh History update.
+- **Refute** if no longer true. Move to {{ doc_paths.epistemic_graveyard }} and replace with stub.
+- **Supersede** if the belief changed. Update to the current claim with clear evidence/history.
+
+{% for e in entries %}
+- **{{ e.name }}**{% if e.id %} ({{ e.id }}){% endif %}: {{ e.days_old }} days stale (last history: {{ e.last_date }})
+{% endfor %}
+
+({{ entry_count }} stale epistemic entries to audit)
 {% elif drift_type == "contested_review" %}
 # Contested Claims Review (Chunk {{ chunk_id }})
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -31,6 +31,7 @@ thresholds:
   orphan_triage: 50
   contested_review_days: 14
   stale_unverified_days: 30
+  stale_epistemic_days: 90
   workflow_repetition: 3
 
 budget:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -455,6 +455,22 @@ class TestFindStaleEpistemicEntries:
         assert len(results) == 1
         assert results[0]["id"] == "E013"
 
+    def test_bullet_prefixed_history_field_is_parsed(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E014: bullet history format (unverified)\n"
+            "- **History:**\n"
+            f"- {old_date}: first noted\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E014"
+
 
 # ------------------------------------------------------------------
 # Workflow repetition detection

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -471,6 +471,56 @@ class TestFindStaleEpistemicEntries:
         assert len(results) == 1
         assert results[0]["id"] == "E014"
 
+    def test_plain_history_field_is_parsed(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E015: plain history format (believed)\n"
+            "History:\n"
+            f"- {old_date}: first noted\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E015"
+
+    def test_bullet_prefixed_plain_history_field_is_parsed(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E017: bullet plain history format (believed)\n"
+            "- History:\n"
+            f"- {old_date}: first noted\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E017"
+
+    def test_plain_post_history_field_date_does_not_override_history_date(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        recent_date = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E016: plain field boundary check (believed)\n"
+            "History:\n"
+            f"- {old_date}: original claim\n"
+            f"Agent guidance: recheck after {recent_date}\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E016"
+
 
 # ------------------------------------------------------------------
 # Workflow repetition detection

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -15,6 +15,7 @@ from engram.fold.chunker import (
     _extract_latest_date,
     _find_claims_by_status,
     _find_orphaned_concepts,
+    _find_stale_epistemic_entries,
     _find_workflow_repetitions,
     _render_item_content,
     compute_budget,
@@ -48,6 +49,7 @@ thresholds:
   orphan_triage: 3
   contested_review_days: 14
   stale_unverified_days: 30
+  stale_epistemic_days: 90
   workflow_repetition: 3
 budget:
   context_limit_chars: 600000
@@ -119,6 +121,18 @@ class TestDriftReportTriggered:
         )
         assert report.triggered({"orphan_triage": 50}) is None
 
+    def test_epistemic_audit_triggered(self):
+        report = DriftReport(
+            epistemic_audit=[{"name": "E001"}],
+        )
+        assert report.triggered({}) == "epistemic_audit"
+
+    def test_epistemic_audit_at_threshold_not_triggered(self):
+        report = DriftReport(
+            epistemic_audit=[{"name": "E001"}],
+        )
+        assert report.triggered({"epistemic_audit": 1}) is None
+
     def test_contested_review_triggered(self):
         report = DriftReport(
             contested_claims=[{"name": f"claim{i}", "days_old": 20} for i in range(6)]
@@ -155,6 +169,13 @@ class TestDriftReportTriggered:
             contested_claims=[{"name": f"claim{i}"} for i in range(6)],
         )
         assert report.triggered({"orphan_triage": 3, "contested_review": 5}) == "orphan_triage"
+
+    def test_priority_order_epistemic_over_contested(self):
+        report = DriftReport(
+            epistemic_audit=[{"name": "E001"}],
+            contested_claims=[{"name": f"claim{i}"} for i in range(6)],
+        )
+        assert report.triggered({"contested_review": 5}) == "epistemic_audit"
 
     def test_priority_order_contested_over_stale(self):
         report = DriftReport(
@@ -319,6 +340,104 @@ class TestFindClaimsByStatus:
         assert results == []
 
 
+class TestFindStaleEpistemicEntries:
+    def test_finds_stale_believed_entry(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E008: harness phase 0 completion (believed)\n"
+            "**History:**\n"
+            f"- {old_date}: backlog noted\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E008"
+        assert results[0]["status"] == "believed"
+
+    def test_threshold_behavior_age_equal_not_stale(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        exact_date = (datetime.now(timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E010: recent enough claim (unverified)\n"
+            "**History:**\n"
+            f"- {exact_date}: noted\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=30,
+        )
+        assert results == []
+
+    def test_queue_reference_since_history_suppresses(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E011: harness phase 0 completion (believed)\n"
+            "**History:**\n"
+            f"- {old_date}: backlog noted\n"
+        )
+
+        note_path = project / "docs" / "working" / "harness_update.md"
+        note_path.parent.mkdir(parents=True, exist_ok=True)
+        note_path.write_text("Harness phase 0 completion is now tracked elsewhere.")
+
+        queue_entries = [
+            {
+                "date": datetime.now(timezone.utc).isoformat(),
+                "type": "doc",
+                "path": "docs/working/harness_update.md",
+                "chars": 100,
+                "pass": "initial",
+            },
+        ]
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+            project_root=project,
+            queue_entries=queue_entries,
+        )
+        assert results == []
+
+    def test_queue_reference_before_history_does_not_suppress(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        history_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        old_queue_date = (datetime.now(timezone.utc) - timedelta(days=150)).isoformat()
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E012: harness phase 0 completion (believed)\n"
+            "**History:**\n"
+            f"- {history_date}: backlog noted\n"
+        )
+
+        note_path = project / "docs" / "working" / "old_note.md"
+        note_path.parent.mkdir(parents=True, exist_ok=True)
+        note_path.write_text("harness phase 0 completion old context")
+
+        queue_entries = [
+            {
+                "date": old_queue_date,
+                "type": "doc",
+                "path": "docs/working/old_note.md",
+                "chars": 100,
+                "pass": "initial",
+            },
+        ]
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+            project_root=project,
+            queue_entries=queue_entries,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E012"
+
+
 # ------------------------------------------------------------------
 # Workflow repetition detection
 # ------------------------------------------------------------------
@@ -404,6 +523,7 @@ class TestScanDrift:
     def test_no_drift_on_empty_docs(self, project, config):
         report = scan_drift(config, project)
         assert report.orphaned_concepts == []
+        assert report.epistemic_audit == []
         assert report.contested_claims == []
         assert report.stale_unverified == []
         assert report.workflow_repetitions == []
@@ -420,6 +540,22 @@ class TestScanDrift:
         assert len(report.orphaned_concepts) == 4
         # threshold is 3, so 4 > 3 triggers
         assert report.triggered(config["thresholds"]) == "orphan_triage"
+
+    def test_epistemic_audit_detected_and_triggered(self, project, config):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E008: harness phase 0 completion (believed)\n"
+            "**History:**\n"
+            f"- {old_date}: backlog noted\n"
+        )
+
+        config["thresholds"]["stale_epistemic_days"] = 90
+        report = scan_drift(config, project)
+        assert len(report.epistemic_audit) == 1
+        assert report.epistemic_audit[0]["id"] == "E008"
+        assert report.triggered(config["thresholds"]) == "epistemic_audit"
 
 
 # ------------------------------------------------------------------
@@ -561,6 +697,31 @@ class TestNextChunk:
         input_text = result.input_path.read_text()
         assert "Orphan Triage Round" in input_text
         assert "orphan_0" in input_text
+
+    def test_epistemic_audit_chunk(self, project, config):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E008: harness phase 0 completion (believed)\n"
+            "**History:**\n"
+            f"- {old_date}: backlog noted\n"
+        )
+        config["thresholds"]["stale_epistemic_days"] = 90
+
+        _write_queue(project, [
+            _make_doc_item(chars=100),
+        ])
+
+        result = next_chunk(config, project)
+        assert result.chunk_type == "epistemic_audit"
+        assert result.items_count == 0
+        assert result.drift_entry_count == 1
+        assert result.remaining_queue == 1
+
+        input_text = result.input_path.read_text()
+        assert "Epistemic Audit Round" in input_text
+        assert "harness phase 0 completion" in input_text
 
     def test_workflow_synthesis_not_repeated_for_same_ids(self, project, config):
         """workflow_synthesis should not re-fire when all CURRENT IDs were already synthesized."""

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -437,6 +437,24 @@ class TestFindStaleEpistemicEntries:
         assert len(results) == 1
         assert results[0]["id"] == "E012"
 
+    def test_post_history_field_date_does_not_override_history_date(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d")
+        recent_date = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E013: parser boundary check (believed)\n"
+            "**History:**\n"
+            f"- {old_date}: original claim\n"
+            f"**Agent guidance:** recheck after {recent_date}\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E013"
+
 
 # ------------------------------------------------------------------
 # Workflow repetition detection

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,6 +105,7 @@ class TestLoadConfig:
         assert config["model"] == "sonnet"
         assert config["budget"]["context_limit_chars"] == 600_000
         assert config["thresholds"]["orphan_triage"] == 50
+        assert config["thresholds"]["stale_epistemic_days"] == 90
 
     def test_missing_config_file(self, tmp_path: Path) -> None:
         with pytest.raises(ConfigError, match="Config not found"):


### PR DESCRIPTION
## Summary
- add `epistemic_audit` drift type to chunker drift model/trigger path
- implement `_find_stale_epistemic_entries()` for believed/unverified claims using last History date, age threshold, and queue-reference suppression
- wire `scan_drift()` + triage chunk accounting + prompt rendering/template for `epistemic_audit`
- add `thresholds.stale_epistemic_days` default (90) to config defaults and generated/example config
- add tests for stale detection positive/negative, threshold behavior, queue suppression, scan_drift trigger, and next_chunk triage branch

## Test Plan
- [x] `python -m pytest tests/ -v`

Fixes #42
