### PR TITLE
fix: parse non-ISO history dates in epistemic_audit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule ".agent-os"]
 	path = .agent-os
 	url = git@github.com:rajeshgoli/agent-os.git
+	branch = main

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -33,8 +33,8 @@ _MONTH_PATTERN = (
 )
 _NATURAL_DATE_RE = re.compile(
     rf"\b(?:(?P<month>{_MONTH_PATTERN})\.?\s+(?P<day>\d{{1,2}})"
-    rf"(?:,\s*(?P<year>\d{{4}}))?|(?P<day2>\d{{1,2}})\s+"
-    rf"(?P<month2>{_MONTH_PATTERN})\.?(?:,\s*(?P<year2>\d{{4}}))?)\b",
+    rf"(?:(?:,\s*|\s+)(?P<year>\d{{4}}))?|(?P<day2>\d{{1,2}})\s+"
+    rf"(?P<month2>{_MONTH_PATTERN})\.?(?:(?:,\s*|\s+)(?P<year2>\d{{4}}))?)\b",
     re.IGNORECASE,
 )
 _MONTH_TO_NUM = {

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -71,6 +71,24 @@ This is a dedicated review round for stale epistemic entries.
 These entries are marked believed/unverified, older than the audit threshold,
 and have not been referenced by recent queue items.
 
+{% if ref_commit %}
+## Temporal Context
+
+Living docs are current through **{{ ref_date }}** (commit `{{ ref_commit[:12] }}`).
+Validate each belief against code/docs at that commit, NOT today's workspace state.
+
+To inspect the project at that reference point:
+```
+git worktree add /tmp/engram-epistemic-{{ ref_commit[:8] }} {{ ref_commit }}
+```
+
+Use that worktree to verify whether claims were valid as of the fold context.
+When done:
+```
+git worktree remove /tmp/engram-epistemic-{{ ref_commit[:8] }}
+```
+{% endif %}
+
 For each entry below:
 - **Confirm** if still valid. Keep status and add a fresh History update.
 - **Refute** if no longer true. Move to {{ doc_paths.epistemic_graveyard }} and replace with stub.

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -285,6 +285,26 @@ class TestExtractLatestDate:
     def test_no_dates(self):
         assert _extract_latest_date("no dates here") is None
 
+    def test_month_day_without_year_uses_nearest_past(self):
+        target = datetime.now(timezone.utc) - timedelta(days=120)
+        text = f"- Product {target.strftime('%b %d')}: evidence updated"
+        dt = _extract_latest_date(text)
+        assert dt is not None
+        assert dt <= datetime.now(timezone.utc)
+        assert (datetime.now(timezone.utc) - dt).days >= 90
+
+    def test_month_day_with_year_is_parsed(self):
+        text = "- Product Jan 05, 2025: evidence updated"
+        dt = _extract_latest_date(text)
+        assert dt is not None
+        assert dt.strftime("%Y-%m-%d") == "2025-01-05"
+
+    def test_day_month_year_is_parsed(self):
+        text = "- Product 11 Dec 2025: evidence updated"
+        dt = _extract_latest_date(text)
+        assert dt is not None
+        assert dt.strftime("%Y-%m-%d") == "2025-12-11"
+
 
 # ------------------------------------------------------------------
 # Contested / unverified claim detection
@@ -588,6 +608,38 @@ class TestFindStaleEpistemicEntries:
         )
         assert len(results) == 1
         assert results[0]["id"] == "E016"
+
+    def test_non_iso_history_date_is_stale_candidate(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_human_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%b %d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E019: harness phase 0 completion (believed)\n"
+            "**History:**\n"
+            f"- Product {old_human_date}: moved to backlog\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E019"
+
+    def test_history_line_with_colon_is_not_treated_as_new_field(self, project):
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_human_date = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%b %d")
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E020: harness phase 0 completion (believed)\n"
+            "**History:**\n"
+            f"- Product {old_human_date}: moved to backlog\n"
+        )
+        results = _find_stale_epistemic_entries(
+            epistemic,
+            days_threshold=90,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "E020"
 
 
 # ------------------------------------------------------------------

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -299,11 +299,23 @@ class TestExtractLatestDate:
         assert dt is not None
         assert dt.strftime("%Y-%m-%d") == "2025-01-05"
 
+    def test_month_day_year_without_comma_is_parsed(self):
+        text = "- Product Jan 05 2010: evidence updated"
+        dt = _extract_latest_date(text)
+        assert dt is not None
+        assert dt.strftime("%Y-%m-%d") == "2010-01-05"
+
     def test_day_month_year_is_parsed(self):
-        text = "- Product 11 Dec 2025: evidence updated"
+        text = "- Product 11 Dec, 2025: evidence updated"
         dt = _extract_latest_date(text)
         assert dt is not None
         assert dt.strftime("%Y-%m-%d") == "2025-12-11"
+
+    def test_day_month_year_without_comma_is_parsed(self):
+        text = "- Product 11 Dec 2010: evidence updated"
+        dt = _extract_latest_date(text)
+        assert dt is not None
+        assert dt.strftime("%Y-%m-%d") == "2010-12-11"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- parse month-name history dates used in living docs (e.g. `Dec 11`, `Jan 05, 2025`, `11 Dec 2025`)
- infer missing year as nearest past occurrence to avoid future skew
- stop treating free-form history lines with colons as new epistemic fields
- add regression tests for non-ISO date extraction and stale-epistemic detection

## Test Plan
- [x] python -m pytest tests/test_chunker.py -v
- [x] python -m pytest tests/ -q

Fixes #47