### PR TITLE
Enforce evidence-gated epistemic audits

### DIFF
--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -71,10 +71,31 @@ This is a dedicated review round for stale epistemic entries.
 These entries are marked believed/unverified, older than the audit threshold,
 and have not been referenced by recent queue items.
 
+{% if ref_commit %}
+## Temporal Context
+
+Living docs are current through **{{ ref_date }}** (commit `{{ ref_commit[:12] }}`).
+Validate each belief against code/docs at that commit, NOT today's workspace state.
+
+To inspect the project at that reference point:
+```
+git worktree add /tmp/engram-epistemic-{{ ref_commit[:8] }} {{ ref_commit }}
+```
+
+Use that worktree to verify whether claims were valid as of the fold context.
+When done:
+```
+git worktree remove /tmp/engram-epistemic-{{ ref_commit[:8] }}
+```
+{% endif %}
+
 For each entry below:
-- **Confirm** if still valid. Keep status and add a fresh History update.
+- **Confirm** if still valid. Keep status and add claim-specific evidence from the reference commit:
+  `- Evidence@<commit> <path>:<line>: <finding> -> believed|unverified`
 - **Refute** if no longer true. Move to {{ doc_paths.epistemic_graveyard }} and replace with stub.
 - **Supersede** if the belief changed. Update to the current claim with clear evidence/history.
+- If no direct evidence exists for a retained belief, downgrade status (`believed` -> `contested|unverified`) or move to graveyard if refuted.
+- Do NOT use generic lines like `reaffirmed -> believed`.
 
 {% for e in entries %}
 - **{{ e.name }}**{% if e.id %} ({{ e.id }}){% endif %}: {{ e.days_old }} days stale (last history: {{ e.last_date }})

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -225,6 +225,43 @@ Just a statement with no evidence chain.
 """
         assert validate_epistemic_state(doc) == []
 
+    def test_reaffirmed_believed_line_rejected(self) -> None:
+        doc = """\
+## E001: claim (believed)
+**History:**
+- Epistemic audit Feb 21, 2026 (a3e0b731): reaffirmed -> believed
+"""
+        violations = validate_epistemic_state(doc)
+        assert len(violations) == 2
+        assert any("reaffirmed" in v.message for v in violations)
+
+    def test_epistemic_audit_believed_requires_evidence_at(self) -> None:
+        doc = """\
+## E001: claim (believed)
+**History:**
+- Epistemic audit Feb 21, 2026 (a3e0b731): reviewed
+"""
+        violations = validate_epistemic_state(doc)
+        assert len(violations) == 1
+        assert "Evidence@<commit>" in violations[0].message
+
+    def test_epistemic_audit_believed_with_evidence_at_is_valid(self) -> None:
+        doc = """\
+## E001: claim (believed)
+**History:**
+- Epistemic audit Feb 21, 2026 (a3e0b731): reviewed
+- Evidence@a3e0b731 docs/decisions/timeline.md:42: confirmed by commit-era timeline
+"""
+        assert validate_epistemic_state(doc) == []
+
+    def test_epistemic_audit_contested_without_evidence_at_is_valid(self) -> None:
+        doc = """\
+## E001: claim (contested)
+**History:**
+- Epistemic audit Feb 21, 2026 (a3e0b731): unresolved
+"""
+        assert validate_epistemic_state(doc) == []
+
 
 # ======================================================================
 # Schema: workflow_registry

--- a/tests/test_temporal_orphan_triage.py
+++ b/tests/test_temporal_orphan_triage.py
@@ -431,6 +431,32 @@ class TestTriagePromptTemporalContext:
         # The template only has the temporal block inside orphan_triage section
         assert "Temporal Context" not in output
 
+    def test_epistemic_audit_includes_evidence_gate_instructions(self, tmp_path: Path) -> None:
+        from engram.fold.prompt import render_triage_input
+        from engram.fold.chunker import DriftReport
+
+        drift = DriftReport(
+            epistemic_audit=[{
+                "name": "E008: Harness Phase 0 completion (believed)",
+                "id": "E008",
+                "days_old": 72,
+                "last_date": "2025-12-11",
+            }],
+        )
+        doc_paths = _fake_doc_paths(tmp_path)
+
+        output = render_triage_input(
+            drift_type="epistemic_audit",
+            drift_report=drift,
+            chunk_id=13,
+            doc_paths=doc_paths,
+            ref_commit="abc123def456789012345678901234567890abcd",
+            ref_date="2026-01-01",
+        )
+        assert "Temporal Context" in output
+        assert "Evidence@<commit>" in output
+        assert "Do NOT use generic lines like `reaffirmed -> believed`." in output
+
 
 # ==================================================================
 # 8. fold_from lifecycle — set → use → clear


### PR DESCRIPTION
## Summary
- tighten `epistemic_audit` prompt instructions to require claim-specific `Evidence@<commit>` bullets for retained beliefs
- preserve temporal commit-pinned worktree instructions in epistemic audit prompts
- add linter rule rejecting generic `reaffirmed -> believed` history lines
- add linter rule requiring `Evidence@<commit>` when an epistemic-audited entry remains `believed`/`unverified`
- add test coverage for both prompt rendering and schema validation

## Validation
- `python -m pytest tests/test_linter.py tests/test_temporal_orphan_triage.py -v`
- `python -m pytest tests/ -v`

Fixes #49
