### PR TITLE
Lint: reject legacy compacted dead/refuted living headings

### DIFF
--- a/engram/linter/schema.py
+++ b/engram/linter/schema.py
@@ -53,6 +53,16 @@ WORKFLOW_STUB_RE = re.compile(
     r'^##\s+W\d{3,}:\s+.+\((?:SUPERSEDED|MERGED)[^)]*\)\s*→\s*\S+'
 )
 
+# Legacy compacted headings (no stable ID) should not remain in living docs.
+LEGACY_COMPACTED_DEAD_RE = re.compile(
+    r'^##\s+.+\(\s*DEAD\s*\)\s+—\s+\*compacted\*\s*$',
+    re.IGNORECASE,
+)
+LEGACY_COMPACTED_REFUTED_RE = re.compile(
+    r'^##\s+.+\(\s*REFUTED\s*\)\s+—\s+\*compacted\*\s*$',
+    re.IGNORECASE,
+)
+
 # Required field patterns (bold markdown fields inside a section body)
 _CODE_RE = re.compile(r'^\s*-?\s*\*?\*?Code\*?\*?:', re.MULTILINE)
 _EVIDENCE_RE = re.compile(r'^\s*-?\s*\*?\*?Evidence\*?\*?:', re.MULTILINE)
@@ -99,6 +109,14 @@ def validate_concept_registry(content: str) -> list[Violation]:
     for section in sections:
         heading = section["heading"]
         entry_id = extract_id(heading)
+
+        if not entry_id and LEGACY_COMPACTED_DEAD_RE.match(heading):
+            violations.append(Violation(
+                "concepts", None,
+                "Legacy compacted DEAD heading found in living concept doc; "
+                "move it fully to concept_graveyard.md",
+            ))
+            continue
 
         if not entry_id:
             continue  # preamble or non-entry section
@@ -150,6 +168,14 @@ def validate_epistemic_state(content: str) -> list[Violation]:
     for section in sections:
         heading = section["heading"]
         entry_id = extract_id(heading)
+
+        if not entry_id and LEGACY_COMPACTED_REFUTED_RE.match(heading):
+            violations.append(Violation(
+                "epistemic", None,
+                "Legacy compacted REFUTED heading found in living epistemic doc; "
+                "move it fully to epistemic_graveyard.md",
+            ))
+            continue
 
         if not entry_id:
             continue

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -160,6 +160,12 @@ class TestConceptRegistrySchema:
             violations = validate_concept_registry(doc)
             assert violations == [], f"Failed for format: {fmt}"
 
+    def test_legacy_compacted_dead_heading_rejected(self) -> None:
+        doc = "## data_loader (DEAD) — *compacted*\n"
+        violations = validate_concept_registry(doc)
+        assert len(violations) == 1
+        assert "Legacy compacted DEAD heading" in violations[0].message
+
 
 # ======================================================================
 # Schema: epistemic_state
@@ -224,6 +230,12 @@ Just a statement with no evidence chain.
 **Evidence:** data
 """
         assert validate_epistemic_state(doc) == []
+
+    def test_legacy_compacted_refuted_heading_rejected(self) -> None:
+        doc = "## Duplicate swings (REFUTED) — *compacted*\n"
+        violations = validate_epistemic_state(doc)
+        assert len(violations) == 1
+        assert "Legacy compacted REFUTED heading" in violations[0].message
 
 
 # ======================================================================


### PR DESCRIPTION
## Summary
- add linter checks to reject legacy compacted headings in living docs:
  - concept headings like `## ... (DEAD) — *compacted*`
  - epistemic headings like `## ... (REFUTED) — *compacted*`
- these headings lack stable IDs and keep dead/refuted content in living docs unnecessarily
- force migration toward graveyard-only storage for those legacy artifacts

## Validation
- `python -m pytest tests/test_linter.py -v`
- `python -m pytest tests/ -v`

Related: #51
