### PR TITLE
Add inferred per-ID epistemic history sharding

### DIFF
--- a/engram/epistemic_history.py
+++ b/engram/epistemic_history.py
@@ -1,0 +1,132 @@
+"""Helpers for externalized epistemic history files.
+
+External history path is inferred from the epistemic state doc path and entry ID:
+`<epistemic_state_stem>/<EID>.md`.
+Example: docs/decisions/epistemic_state.md -> docs/decisions/epistemic_state/E005.md
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+# Recognized epistemic field headers. Used to detect field boundaries without
+# misclassifying free-form history lines like "Product Dec 11: ...".
+EPISTEMIC_FIELD_NAMES = {
+    "current position",
+    "evidence",
+    "history",
+    "agent guidance",
+    "corrected by",
+    "superseded by",
+}
+
+# Markdown-style field header, e.g. "History:" / "**History:**" / "- **History:**"
+FIELD_HEADER_RE = re.compile(r"^(?:\*\*)?([A-Za-z][A-Za-z _/-]*?)(?:\*\*)?:\s*(.*)$")
+
+
+def infer_history_dir(epistemic_doc_path: Path) -> Path:
+    """Return inferred history directory for an epistemic state doc."""
+    return epistemic_doc_path.with_suffix("")
+
+
+def infer_history_path(epistemic_doc_path: Path, entry_id: str) -> Path:
+    """Return inferred history file path for an epistemic entry ID."""
+    return infer_history_dir(epistemic_doc_path) / f"{entry_id}.md"
+
+
+def extract_inline_history_lines(section_text: str) -> list[str]:
+    """Extract lines in the History field from an epistemic section.
+
+    Returns content lines only (without the `History:` header line).
+    """
+    history_lines: list[str] = []
+    in_history = False
+
+    for line in section_text.splitlines():
+        stripped = line.strip()
+        normalized = stripped.removeprefix("- ").strip()
+        field_match = FIELD_HEADER_RE.match(normalized)
+        field_name = field_match.group(1).strip().lower() if field_match else None
+
+        if field_name == "history":
+            in_history = True
+            remainder = field_match.group(2).strip() if field_match else ""
+            if remainder:
+                history_lines.append(remainder)
+            continue
+
+        if not in_history:
+            continue
+
+        if stripped.startswith("## "):
+            break
+        # Stop at next recognized epistemic field.
+        if field_match and field_name in EPISTEMIC_FIELD_NAMES and field_name != "history":
+            break
+
+        if stripped:
+            history_lines.append(stripped)
+
+    return history_lines
+
+
+def remove_inline_history(section_text: str) -> tuple[str, list[str]]:
+    """Remove the History field block from a section.
+
+    Returns `(updated_section_text, extracted_history_lines)`.
+    """
+    lines = section_text.splitlines()
+    start_idx: int | None = None
+    end_idx: int | None = None
+    extracted: list[str] = []
+    in_history = False
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        normalized = stripped.removeprefix("- ").strip()
+        field_match = FIELD_HEADER_RE.match(normalized)
+        field_name = field_match.group(1).strip().lower() if field_match else None
+
+        if field_name == "history" and start_idx is None:
+            start_idx = i
+            in_history = True
+            remainder = field_match.group(2).strip() if field_match else ""
+            if remainder:
+                extracted.append(remainder)
+            continue
+
+        if not in_history:
+            continue
+
+        if stripped.startswith("## "):
+            end_idx = i
+            break
+        if field_match and field_name in EPISTEMIC_FIELD_NAMES and field_name != "history":
+            end_idx = i
+            break
+        extracted.append(line)
+
+    if start_idx is None:
+        return section_text, []
+
+    if end_idx is None:
+        end_idx = len(lines)
+
+    new_lines = lines[:start_idx] + lines[end_idx:]
+
+    # Collapse repeated blank lines after removing block.
+    compacted: list[str] = []
+    prev_blank = False
+    for line in new_lines:
+        blank = line.strip() == ""
+        if blank and prev_blank:
+            continue
+        compacted.append(line)
+        prev_blank = blank
+
+    # Trim extracted history lines to non-empty meaningful lines.
+    cleaned = [ln.rstrip() for ln in extracted if ln.strip()]
+    return "\n".join(compacted), cleaned
+

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -151,6 +151,7 @@ def render_agent_prompt(
         if project_root
         else "engram lint --project-root <project_root>"
     )
+    epistemic_history_dir = _epistemic_history_dir_str(doc_paths)
 
     return (
         f"You are processing a knowledge fold chunk.\n"
@@ -159,6 +160,8 @@ def render_agent_prompt(
         f"- Do NOT use the Task tool or spawn sub-agents. Do all work directly.\n"
         f"- Do NOT use Write to overwrite entire files. Use Edit for surgical updates only.\n"
         f"- Be SUCCINCT. High information density, no filler, no narrative prose.\n"
+        f"- Do NOT read per-ID epistemic history files under {epistemic_history_dir}/E*.md.\n"
+        f"  They are append-only logs; when needed, append via Bash without opening them.\n"
         f"\n"
         f"Read the input file at {input_path.resolve()} — it contains system instructions\n"
         f"and new content covering {date_range}.\n"

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from jinja2 import Environment, FileSystemLoader
 
+from engram.epistemic_history import infer_history_dir
+
 _TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
 
@@ -33,6 +35,11 @@ def _stringify_paths(doc_paths: dict[str, Path]) -> dict[str, str]:
     return {k: str(v) for k, v in doc_paths.items()}
 
 
+def _epistemic_history_dir_str(doc_paths: dict[str, Path]) -> str:
+    """Infer history directory path for epistemic per-ID history files."""
+    return str(infer_history_dir(doc_paths["epistemic"]))
+
+
 def render_chunk_input(
     *,
     chunk_id: int,
@@ -52,6 +59,7 @@ def render_chunk_input(
 
     instructions = template.render(
         doc_paths=_stringify_paths(doc_paths),
+        epistemic_history_dir=_epistemic_history_dir_str(doc_paths),
         pre_assigned_ids=pre_assigned_ids,
     )
 
@@ -109,6 +117,7 @@ def render_triage_input(
         entries=entries,
         chunk_id=chunk_id,
         doc_paths=_stringify_paths(doc_paths),
+        epistemic_history_dir=_epistemic_history_dir_str(doc_paths),
         entry_count=len(entries),
         ref_commit=ref_commit,
         ref_date=ref_date,

--- a/engram/migrate_epistemic_history.py
+++ b/engram/migrate_epistemic_history.py
@@ -1,0 +1,123 @@
+"""One-time migration: externalize inline epistemic history to per-ID files."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from engram.epistemic_history import infer_history_path, remove_inline_history
+from engram.parse import extract_id, is_stub, parse_sections
+
+
+@dataclass
+class EpistemicHistoryMigrationResult:
+    """Summary of externalization changes."""
+
+    migrated_entries: int
+    created_files: int
+    appended_blocks: int
+
+
+def _extract_subject(heading: str) -> str:
+    """Extract human-readable subject from an epistemic heading line."""
+    text = re.sub(r"^##\s+E\d{3,}:\s+", "", heading.strip())
+    text = re.sub(r"\s+\([^)]*\)\s*(?:→\s+\S+)?\s*$", "", text).strip()
+    return text or "claim"
+
+
+def _ensure_history_heading(path: Path, entry_id: str, subject: str) -> bool:
+    """Ensure history file exists and contains heading for the entry ID.
+
+    Returns True when a new file was created.
+    """
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "# Epistemic History\n\n"
+            f"## {entry_id}: {subject}\n\n",
+        )
+        return True
+
+    text = path.read_text()
+    if re.search(rf"^##\s+{re.escape(entry_id)}\b", text, re.MULTILINE):
+        return False
+
+    with open(path, "a") as fh:
+        if not text.endswith("\n"):
+            fh.write("\n")
+        fh.write(f"\n## {entry_id}: {subject}\n\n")
+    return False
+
+
+def _append_history_lines(path: Path, lines: list[str]) -> None:
+    """Append a migrated history block to a per-ID history file."""
+    normalized: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("- "):
+            normalized.append(stripped)
+        else:
+            normalized.append(f"- {stripped}")
+
+    if not normalized:
+        return
+
+    text = path.read_text()
+    with open(path, "a") as fh:
+        if not text.endswith("\n"):
+            fh.write("\n")
+        for line in normalized:
+            fh.write(f"{line}\n")
+        fh.write("\n")
+
+
+def externalize_epistemic_history(epistemic_path: Path) -> EpistemicHistoryMigrationResult:
+    """Move inline History blocks from epistemic_state.md into inferred E###.md files."""
+    if not epistemic_path.exists():
+        return EpistemicHistoryMigrationResult(0, 0, 0)
+
+    original = epistemic_path.read_text()
+    sections = parse_sections(original)
+    lines = original.splitlines()
+
+    migrated_entries = 0
+    created_files = 0
+    appended_blocks = 0
+
+    # Iterate bottom-up to keep parse indices stable during line replacement.
+    for sec in reversed(sections):
+        entry_id = extract_id(sec["heading"])
+        if not entry_id:
+            continue
+        if is_stub(sec["heading"]) or sec["status"] == "refuted":
+            continue
+
+        section_text = "\n".join(lines[sec["start"]:sec["end"]])
+        updated_section, history_lines = remove_inline_history(section_text)
+        if not history_lines:
+            continue
+
+        history_path = infer_history_path(epistemic_path, entry_id)
+        subject = _extract_subject(sec["heading"])
+        if _ensure_history_heading(history_path, entry_id, subject):
+            created_files += 1
+        _append_history_lines(history_path, history_lines)
+        appended_blocks += 1
+
+        lines[sec["start"]:sec["end"]] = updated_section.splitlines()
+        migrated_entries += 1
+
+    updated = "\n".join(lines)
+    if original.endswith("\n"):
+        updated += "\n"
+    epistemic_path.write_text(updated)
+
+    return EpistemicHistoryMigrationResult(
+        migrated_entries=migrated_entries,
+        created_files=created_files,
+        appended_blocks=appended_blocks,
+    )
+

--- a/engram/server/dispatcher.py
+++ b/engram/server/dispatcher.py
@@ -145,6 +145,7 @@ class Dispatcher:
                 pre_assigned_ids=pre_assigned if pre_assigned else None,
                 expected_growth=chunk.chunk_chars,
                 config=self._config,
+                project_root=self._project_root,
             )
 
             if result.passed:
@@ -199,7 +200,7 @@ class Dispatcher:
                 )
 
                 from engram.linter import lint
-                result = lint(after_contents, graveyard_docs, self._config)
+                result = lint(after_contents, graveyard_docs, self._config, doc_paths=doc_paths)
 
                 if result.passed:
                     self._db.update_dispatch_state(dispatch_id, "validated")
@@ -227,7 +228,7 @@ class Dispatcher:
                         graveyard2 = read_docs(
                             doc_paths, ("concept_graveyard", "epistemic_graveyard"),
                         )
-                        result2 = lint(after2, graveyard2, self._config)
+                        result2 = lint(after2, graveyard2, self._config, doc_paths=doc_paths)
                         if result2.passed:
                             self._db.update_dispatch_state(dispatch_id, "validated")
                             self._db.mark_l0_stale()  # stale BEFORE committed

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -43,9 +43,8 @@ All required fields must be present.
 
     ## E{NNN}: {name} (believed|contested|unverified)
     **Current position:** 1-2 sentences.
-    **History:**
-    - #issue: "claim" → status
     **Agent guidance:** 1 sentence only.
+    [Optional inline **History:** is allowed, but prefer external per-ID history file.]
 
 **Workflow registry:**
 
@@ -98,6 +97,8 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Workflow registry: structured fields only. Context + trigger/method.
 - DEAD/refuted entries: 1-2 sentences max. Key lesson + replacement.
 - **Budget matters.** Every line stays in context for future chunks. Be ruthless about cutting words.
+- For epistemic entries, keep the main file concise. Store detailed append-only history in inferred files:
+  `{{ epistemic_history_dir }}/E{NNN}.md` (derive from entry ID; do NOT add a `History file:` field).
 
 ## Important
 

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -90,9 +90,12 @@ git worktree remove /tmp/engram-epistemic-{{ ref_commit[:8] }}
 {% endif %}
 
 For each entry below:
-- **Confirm** if still valid. Keep status and add a fresh History update.
+- **Confirm** if still valid. Keep status and append a fresh history update to
+  `{{ epistemic_history_dir }}/E{NNN}.md` for that entry ID.
 - **Refute** if no longer true. Move to {{ doc_paths.epistemic_graveyard }} and replace with stub.
 - **Supersede** if the belief changed. Update to the current claim with clear evidence/history.
+
+Do not add a `History file:` line in main epistemic entries. History file path is inferred from ID.
 
 {% for e in entries %}
 - **{{ e.name }}**{% if e.id %} ({{ e.id }}){% endif %}: {{ e.days_old }} days stale (last history: {{ e.last_date }})

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -96,6 +96,9 @@ For each entry below:
 - **Supersede** if the belief changed. Update to the current claim with clear evidence/history.
 
 Do not add a `History file:` line in main epistemic entries. History file path is inferred from ID.
+Do not read per-ID history files (`{{ epistemic_history_dir }}/E*.md`) during audit.
+Treat them as append-only logs: decide from main living docs + temporal worktree evidence,
+then append one concise bullet via Bash per retained claim.
 
 {% for e in entries %}
 - **{{ e.name }}**{% if e.id %} ({{ e.id }}){% endif %}: {{ e.days_old }} days stale (last history: {{ e.last_date }})

--- a/tests/test_epistemic_history_migration.py
+++ b/tests/test_epistemic_history_migration.py
@@ -52,3 +52,21 @@ def test_migration_is_noop_when_no_inline_history(tmp_path: Path) -> None:
     assert result.appended_blocks == 0
     assert epistemic.read_text() == before
 
+
+def test_bold_history_header_does_not_emit_stray_marker(tmp_path: Path) -> None:
+    epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
+    epistemic.parent.mkdir(parents=True, exist_ok=True)
+    epistemic.write_text(
+        "# Epistemic State\n\n"
+        "## E015: bold header parsing (believed)\n"
+        "**Current position:** valid.\n"
+        "- **History:**\n"
+        "- Product Dec 12: validated\n"
+        "**Agent guidance:** continue.\n",
+    )
+
+    externalize_epistemic_history(epistemic)
+    history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E015.md"
+    content = history_file.read_text()
+    assert "- **" not in content
+    assert "- Product Dec 12: validated" in content

--- a/tests/test_epistemic_history_migration.py
+++ b/tests/test_epistemic_history_migration.py
@@ -1,0 +1,54 @@
+"""Tests for epistemic history externalization migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from engram.migrate_epistemic_history import externalize_epistemic_history
+
+
+def test_externalizes_inline_history_into_inferred_file(tmp_path: Path) -> None:
+    epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
+    epistemic.parent.mkdir(parents=True, exist_ok=True)
+    epistemic.write_text(
+        "# Epistemic State\n\n"
+        "## E005: Ground truth annotation > voting (believed)\n"
+        "**Current position:** Better signal quality.\n"
+        "**History:**\n"
+        "- 2026-02-21: Confirmed from interview notes\n"
+        "**Agent guidance:** Use annotation-first.\n",
+    )
+
+    result = externalize_epistemic_history(epistemic)
+    assert result.migrated_entries == 1
+    assert result.created_files == 1
+    assert result.appended_blocks == 1
+
+    updated = epistemic.read_text()
+    assert "**History:**" not in updated
+    assert "Ground truth annotation > voting (believed)" in updated
+
+    history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E005.md"
+    assert history_file.exists()
+    content = history_file.read_text()
+    assert "## E005:" in content
+    assert "2026-02-21: Confirmed from interview notes" in content
+
+
+def test_migration_is_noop_when_no_inline_history(tmp_path: Path) -> None:
+    epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
+    epistemic.parent.mkdir(parents=True, exist_ok=True)
+    epistemic.write_text(
+        "# Epistemic State\n\n"
+        "## E010: claim (believed)\n"
+        "**Current position:** still believed.\n"
+        "**Agent guidance:** monitor.\n",
+    )
+    before = epistemic.read_text()
+
+    result = externalize_epistemic_history(epistemic)
+    assert result.migrated_entries == 0
+    assert result.created_files == 0
+    assert result.appended_blocks == 0
+    assert epistemic.read_text() == before
+


### PR DESCRIPTION
## Summary
- add inferred per-entry epistemic history paths (`epistemic_state/E###.md`) with no `History file:` metadata
- allow non-refuted epistemic entries to validate via inferred external history files (ID-checked)
- update stale epistemic/claim drift detection to read inline + external history and use latest date
- update fold/triage prompts to keep main epistemic entries concise and append detail to inferred history files
- add `engram migrate-epistemic-history` command to externalize inline history blocks
- add tests for linter, chunker, migration, and CLI

## Test Plan
- python -m pytest tests/ -v

Fixes #51
