### PR TITLE
Rename workflow_synthesis spec to ticket 57

### DIFF
--- a/specs/57_workflow_synthesis_formatting_and_cooldown.md
+++ b/specs/57_workflow_synthesis_formatting_and_cooldown.md
@@ -1,4 +1,4 @@
-# Ticket 28 — Workflow synthesis formatting + safe cooldown
+# Ticket 57 — Workflow synthesis formatting + safe cooldown
 
 ## Problems
 
@@ -51,4 +51,3 @@ were “synthesized”, and engram may skip re-triggering synthesis even though 
 ## Classification
 
 Single ticket.
-


### PR DESCRIPTION
Renames the spec file to match GitHub issue #57 (keeping ticket numbering consistent).\n\nRefs #57