### PR TITLE
Fix fold chunk prompt friction (IDs/orphans/path casing)

### DIFF
--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -1008,29 +1008,10 @@ def next_chunk(
     for item in chunk_items:
         items_content += _render_item_content(item, project_root)
 
-    # Include orphan advisory (below threshold, informational)
-    orphan_advisory = ""
-    if drift.orphaned_concepts:
-        orphan_advisory = (
-            "## [ORPHANED CONCEPTS] Active concepts with missing source files\n\n"
-        )
-        if fold_from and ref_commit:
-            orphan_advisory += (
-                f"**Note:** Living docs are current through {fold_from} "
-                f"(commit `{ref_commit[:12]}`). "
-                f"Only files missing at that commit are listed.\n\n"
-            )
-        for o in drift.orphaned_concepts:
-            orphan_advisory += f"- **{o['name']}**: {', '.join(o['paths'])}\n"
-        orphan_advisory += (
-            f"\n({len(drift.orphaned_concepts)} orphaned concepts found)\n\n---\n\n"
-        )
-
     input_content = render_chunk_input(
         chunk_id=chunk_id,
         date_range=date_range,
         items_content=items_content,
-        orphan_advisory=orphan_advisory,
         pre_assigned_ids=pre_assigned,
         doc_paths=doc_paths,
     )

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -45,7 +45,6 @@ def render_chunk_input(
     chunk_id: int,
     date_range: str,
     items_content: str,
-    orphan_advisory: str,
     pre_assigned_ids: dict[str, list[str]],
     doc_paths: dict[str, Path],
 ) -> str:
@@ -66,9 +65,6 @@ def render_chunk_input(
     content = instructions
     content += f"\n# New Content ({date_range})\n"
     content += f"# Chunk {chunk_id}\n\n"
-
-    if orphan_advisory:
-        content += orphan_advisory
 
     content += items_content
     return content
@@ -181,7 +177,7 @@ def render_agent_prompt(
         f"- USER PROMPTS encode the project owner's intent — they are authoritative\n"
         f"- DEAD/refuted entries: 1-2 sentences max. Key lesson + what replaced it.\n"
         f"- Process ALL items in the chunk\n"
-        f"- Use ONLY pre-assigned IDs for new entries (listed in the input file)\n"
+        f"- Use ONLY IDs listed under 'Pre-assigned IDs for this chunk'. If none are listed, do NOT create new IDs in this chunk.\n"
         f"\n"
         f"After All Edits: Lint Check (Required)\n"
         f"\n"

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -14,14 +14,17 @@ Read the new content below, then edit the 4 living docs using your file editing 
 Every entry uses a permanent stable ID: C### for concepts, E### for claims, W### for workflows.
 IDs survive renames, refactoring, and evolution. Never reuse an ID.
 
-{% if pre_assigned_ids %}
 ### Pre-assigned IDs for this chunk
 
 Use ONLY these IDs for new entries. Do NOT invent your own.
+If no IDs are listed, do NOT create new entries/IDs in this chunk.
 
+{% if pre_assigned_ids %}
 {% for cat, ids in pre_assigned_ids.items() %}
 - {{ cat }}: {{ ids | join(', ') }}
 {% endfor %}
+{% else %}
+- (none)
 {% endif %}
 
 ## Entry Formats
@@ -110,3 +113,4 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Do NOT add entries about the fold process itself.
 - When a concept's source files are deleted, mark it DEAD.
 - When an ORPHANED CONCEPTS section is present, triage each one.
+- Treat repo paths as case-sensitive. Do not copy paths from issues/comments into living docs unless you are confident the casing matches the repo. If unsure, omit the path or use the repo-canonical casing already used elsewhere.


### PR DESCRIPTION
## Summary
- Normal fold chunks always include an explicit "Pre-assigned IDs" section; when empty, it says "(none)" and forbids inventing IDs.
- Normal fold chunks no longer include orphan triage sections; orphan triage is reserved for orphan_triage drift chunks.
- Fold prompt hardening: treat repo paths as case-sensitive; don’t propagate mis-cased paths from issues/comments into living docs.

## Test Plan
- `source venv/bin/activate && python -m pytest tests/ -q`

Fixes #61
