### PR TITLE
Ensure non-empty pre-assigned IDs for fold chunks

### DIFF
--- a/engram/config.py
+++ b/engram/config.py
@@ -39,6 +39,12 @@ DEFAULTS: dict[str, Any] = {
         "stale_unverified_days": 30,
         "stale_epistemic_days": 90,
         "workflow_repetition": 3,
+        # Reserve a small pool of IDs for normal fold chunks so background
+        # agents can add genuinely new entries without inventing IDs even when
+        # heuristics underestimate new entities.
+        "min_preassign_concepts": 1,
+        "min_preassign_epistemic": 1,
+        "min_preassign_workflows": 1,
     },
     "budget": {
         "context_limit_chars": 600_000,

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -993,12 +993,16 @@ def next_chunk(
 
     # Pre-assign IDs
     estimates = estimate_new_entities(chunk_items)
+    thresholds = config.get("thresholds", {})
+    min_preassign_concepts = int(thresholds.get("min_preassign_concepts", 0) or 0)
+    min_preassign_epistemic = int(thresholds.get("min_preassign_epistemic", 0) or 0)
+    min_preassign_workflows = int(thresholds.get("min_preassign_workflows", 0) or 0)
     db_path = engram_dir / "engram.db"
     with IDAllocator(db_path) as allocator:
         pre_assigned = allocator.pre_assign_for_chunk(
-            new_concepts=estimates["C"],
-            new_epistemic=estimates["E"],
-            new_workflows=estimates["W"],
+            new_concepts=max(estimates["C"], min_preassign_concepts),
+            new_epistemic=max(estimates["E"], min_preassign_epistemic),
+            new_workflows=max(estimates["W"], min_preassign_workflows),
         )
 
     date_range = f"{chunk_items[0]['date'][:10]} to {chunk_items[-1]['date'][:10]}"

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1042,7 +1042,7 @@ class TestNextChunk:
         # Verify prompt file content
         prompt_text = result.prompt_path.read_text()
         assert "knowledge fold chunk" in prompt_text
-        assert "Pre-assigned IDs for this chunk" in input_text
+        assert "Pre-assigned IDs for this chunk" in prompt_text
 
     def test_fold_chunk_does_not_include_orphan_triage_section(self, project, config):
         registry = project / "docs" / "decisions" / "concept_registry.md"


### PR DESCRIPTION
## Summary
- Always reserves a small pool of pre-assigned IDs for normal fold chunks (defaults: 1 C / 1 E / 1 W) so background agents can add genuinely-new entries without inventing IDs even when heuristics undercount.
- Fixes test to assert the pre-assigned guidance against `prompt_text` (not `input_text`).

## Notes
- These floors are configurable via `thresholds.min_preassign_concepts|epistemic|workflows`.

## Test Plan
- `source venv/bin/activate && python -m pytest tests/ -q`

Fixes #63
