### PR TITLE
Fix pre-assigned ID collisions + single active chunk lock

### DIFF
--- a/engram/cli.py
+++ b/engram/cli.py
@@ -398,12 +398,13 @@ def _enforce_single_active_chunk(project_root: Path) -> None:
             raw = ""
 
         subjects = ""
-        # Only consider commits strictly AFTER lock creation time.
-        # (Second-level git timestamps can equal the lock second; use strict >.)
+        # Only consider commits at/after lock creation time.
+        # Git commit timestamps are second-granularity; equality is common in
+        # fast automated flows where lock creation and commit happen quickly.
         for line in raw.splitlines():
             try:
                 ts_str, subj = line.split("\t", 1)
-                if int(ts_str) > int(created_epoch):
+                if int(ts_str) >= int(created_epoch):
                     subjects += subj + "\n"
             except ValueError:
                 continue

--- a/engram/cli.py
+++ b/engram/cli.py
@@ -316,7 +316,7 @@ def _enforce_single_active_chunk(project_root: Path) -> None:
         except OSError:
             subjects = ""
 
-        if re.search(rf"Knowledge fold: chunk(?:_| )0*{chunk_id}\\b", subjects):
+        if re.search(rf"Knowledge fold: chunk(?:_| )0*{chunk_id}\b", subjects):
             lock_path.unlink()
             return
 

--- a/specs/65_preassign_unused_ids_and_active_chunk_lock.md
+++ b/specs/65_preassign_unused_ids_and_active_chunk_lock.md
@@ -1,0 +1,39 @@
+# Spec: Pre-assign unused IDs + single active chunk lock (Issue #65)
+
+## Problem
+
+1) Chunk generation can pre-assign stable IDs that already exist in the target project's living docs (C/E/W collision), leaving the fold agent without a usable pool for genuinely-new entries.
+
+2) `engram next-chunk` is re-entrant. Calling it repeatedly can generate multiple chunk files before any are processed, making it easy for a background agent to skip earlier chunks.
+
+## Goals
+
+- Pre-assigned IDs are always **unused** relative to the target project's living docs.
+- `engram next-chunk` produces **at most one active chunk** per project root unless explicitly cleared.
+- Recovery path is explicit and obvious for low-capability agents.
+- Behavior is test-covered and backward-compatible with existing `.engram/` state.
+
+## Proposed changes
+
+### A) Sync allocator counters to existing doc IDs
+
+Before reserving IDs for a chunk, compute the maximum stable ID already present in the target project's living docs for each category (C/E/W) and bump the SQLite `id_counters.next_id` to at least `(max_seen + 1)` inside the same transaction used to reserve the ranges.
+
+### B) Add active chunk lock for CLI `next-chunk`
+
+- On successful chunk generation, write `.engram/active_chunk.yaml` with `{chunk_id, chunk_type, input_path, prompt_path, created_at}`.
+- On subsequent `next-chunk` calls, refuse to generate a new chunk if the lock exists.
+- Provide `engram clear-active-chunk` to delete the lock for recovery.
+- Best-effort auto-clear: if git history includes a commit subject matching `Knowledge fold: chunk <id>`, clear the lock and proceed.
+
+## Acceptance criteria
+
+- Newly generated chunks never pre-assign IDs already present in living docs.
+- Re-running `engram next-chunk` without clearing/completing the active chunk fails fast with a clear message.
+- `engram clear-active-chunk` clears the lock and `next-chunk` works again.
+- Unit tests cover both behaviors.
+
+## Ticket classification
+
+Single ticket.
+

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -166,6 +166,17 @@ class TestPreAssign:
         assert r1["C"] == ["C001", "C002", "C003"]
         assert r2["C"] == ["C004", "C005", "C006"]
 
+    def test_pre_assign_respects_min_next_ids(self, allocator: IDAllocator) -> None:
+        r1 = allocator.pre_assign_for_chunk(new_concepts=2, min_next_ids={"C": 42})
+        assert r1["C"] == ["C042", "C043"]
+        assert allocator.peek("C") == 44
+
+    def test_pre_assign_min_next_ids_does_not_move_backwards(self, allocator: IDAllocator) -> None:
+        allocator.pre_assign_for_chunk(new_concepts=3)  # C001-C003, next=4
+        r2 = allocator.pre_assign_for_chunk(new_concepts=1, min_next_ids={"C": 2})
+        assert r2["C"] == ["C004"]
+        assert allocator.peek("C") == 5
+
 
 # ------------------------------------------------------------------
 # Concurrent safety


### PR DESCRIPTION
Fixes #65.

- Sync IDAllocator counters against existing living-doc IDs before reserving pre-assigned ranges (prevents collisions like C107/E101/W001).
- Add CLI active chunk lock: `engram next-chunk` refuses to generate a new chunk while `.engram/active_chunk.yaml` exists.
- Add `engram clear-active-chunk` recovery command.
- Tests for both behaviors.
