### PR TITLE
Split epistemic per-ID files into current + history

### DIFF
--- a/engram/cli.py
+++ b/engram/cli.py
@@ -518,7 +518,7 @@ def migrate(project_root: str, fold_from: object) -> None:
     help="Project root directory (default: cwd).",
 )
 def migrate_epistemic_history(project_root: str) -> None:
-    """Externalize inline epistemic History blocks into inferred per-ID files."""
+    """Externalize inline epistemic history into split per-ID files."""
     from engram.config import load_config, resolve_doc_paths
     from engram.migrate_epistemic_history import externalize_epistemic_history
 
@@ -530,7 +530,8 @@ def migrate_epistemic_history(project_root: str) -> None:
     result = externalize_epistemic_history(epistemic_path)
     click.echo("Epistemic history migration complete.")
     click.echo(f"  Migrated entries: {result.migrated_entries}")
-    click.echo(f"  Created files: {result.created_files}")
+    click.echo(f"  Created current files: {result.created_current_files}")
+    click.echo(f"  Created history files: {result.created_history_files}")
     click.echo(f"  Appended blocks: {result.appended_blocks}")
 
     from engram.linter import lint_from_paths

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from jinja2 import Environment, FileSystemLoader
 
-from engram.epistemic_history import infer_history_dir
+from engram.epistemic_history import infer_current_dir, infer_history_dir
 
 _TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
@@ -40,6 +40,11 @@ def _epistemic_history_dir_str(doc_paths: dict[str, Path]) -> str:
     return str(infer_history_dir(doc_paths["epistemic"]))
 
 
+def _epistemic_current_dir_str(doc_paths: dict[str, Path]) -> str:
+    """Infer mutable current-state directory for epistemic per-ID files."""
+    return str(infer_current_dir(doc_paths["epistemic"]))
+
+
 def render_chunk_input(
     *,
     chunk_id: int,
@@ -58,6 +63,7 @@ def render_chunk_input(
 
     instructions = template.render(
         doc_paths=_stringify_paths(doc_paths),
+        epistemic_current_dir=_epistemic_current_dir_str(doc_paths),
         epistemic_history_dir=_epistemic_history_dir_str(doc_paths),
         pre_assigned_ids=pre_assigned_ids,
     )
@@ -113,6 +119,7 @@ def render_triage_input(
         entries=entries,
         chunk_id=chunk_id,
         doc_paths=_stringify_paths(doc_paths),
+        epistemic_current_dir=_epistemic_current_dir_str(doc_paths),
         epistemic_history_dir=_epistemic_history_dir_str(doc_paths),
         entry_count=len(entries),
         ref_commit=ref_commit,
@@ -148,6 +155,7 @@ def render_agent_prompt(
         else "engram lint --project-root <project_root>"
     )
     epistemic_history_dir = _epistemic_history_dir_str(doc_paths)
+    epistemic_current_dir = _epistemic_current_dir_str(doc_paths)
 
     return (
         f"You are processing a knowledge fold chunk.\n"
@@ -156,7 +164,8 @@ def render_agent_prompt(
         f"- Do NOT use the Task tool or spawn sub-agents. Do all work directly.\n"
         f"- Do NOT use Write to overwrite entire files. Use Edit for surgical updates only.\n"
         f"- Be SUCCINCT. High information density, no filler, no narrative prose.\n"
-        f"- Do NOT read per-ID epistemic history files under {epistemic_history_dir}/E*.md.\n"
+        f"- Epistemic current-state files live under {epistemic_current_dir}/E*.em and are editable.\n"
+        f"- Do NOT read per-ID epistemic history files under {epistemic_history_dir}/E*.em.\n"
         f"  They are append-only logs; when needed, append via Bash without opening them.\n"
         f"\n"
         f"Read the input file at {input_path.resolve()} — it contains system instructions\n"

--- a/engram/migrate_epistemic_history.py
+++ b/engram/migrate_epistemic_history.py
@@ -59,8 +59,12 @@ def _write_current_state(path: Path, section_text: str) -> bool:
     """Write canonical mutable current-state file for an epistemic entry.
 
     Returns True when a new current-state file was created.
+    Existing files are preserved to keep migration reruns safe.
     """
-    created = not path.exists()
+    if path.exists():
+        return False
+
+    created = True
     path.parent.mkdir(parents=True, exist_ok=True)
     content = section_text.strip()
     if content:

--- a/engram/migrate_epistemic_history.py
+++ b/engram/migrate_epistemic_history.py
@@ -1,4 +1,4 @@
-"""One-time migration: externalize inline epistemic history to per-ID files."""
+"""One-time migration for split per-ID epistemic current/history files."""
 
 from __future__ import annotations
 
@@ -6,7 +6,11 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from engram.epistemic_history import infer_history_path, remove_inline_history
+from engram.epistemic_history import (
+    infer_current_path,
+    infer_history_path,
+    remove_inline_history,
+)
 from engram.parse import extract_id, is_stub, parse_sections
 
 
@@ -15,7 +19,8 @@ class EpistemicHistoryMigrationResult:
     """Summary of externalization changes."""
 
     migrated_entries: int
-    created_files: int
+    created_history_files: int
+    created_current_files: int
     appended_blocks: int
 
 
@@ -50,6 +55,21 @@ def _ensure_history_heading(path: Path, entry_id: str, subject: str) -> bool:
     return False
 
 
+def _write_current_state(path: Path, section_text: str) -> bool:
+    """Write canonical mutable current-state file for an epistemic entry.
+
+    Returns True when a new current-state file was created.
+    """
+    created = not path.exists()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = section_text.strip()
+    if content:
+        path.write_text(f"{content}\n")
+    else:
+        path.write_text("")
+    return created
+
+
 def _append_history_lines(path: Path, lines: list[str]) -> None:
     """Append a migrated history block to a per-ID history file."""
     normalized: list[str] = []
@@ -75,16 +95,17 @@ def _append_history_lines(path: Path, lines: list[str]) -> None:
 
 
 def externalize_epistemic_history(epistemic_path: Path) -> EpistemicHistoryMigrationResult:
-    """Move inline History blocks from epistemic_state.md into inferred E###.md files."""
+    """Split inline epistemic content into per-ID current/history inferred files."""
     if not epistemic_path.exists():
-        return EpistemicHistoryMigrationResult(0, 0, 0)
+        return EpistemicHistoryMigrationResult(0, 0, 0, 0)
 
     original = epistemic_path.read_text()
     sections = parse_sections(original)
     lines = original.splitlines()
 
     migrated_entries = 0
-    created_files = 0
+    created_history_files = 0
+    created_current_files = 0
     appended_blocks = 0
 
     # Iterate bottom-up to keep parse indices stable during line replacement.
@@ -100,15 +121,33 @@ def externalize_epistemic_history(epistemic_path: Path) -> EpistemicHistoryMigra
         if not history_lines:
             continue
 
+        current_path = infer_current_path(epistemic_path, entry_id)
+        if _write_current_state(current_path, updated_section):
+            created_current_files += 1
+
         history_path = infer_history_path(epistemic_path, entry_id)
         subject = _extract_subject(sec["heading"])
         if _ensure_history_heading(history_path, entry_id, subject):
-            created_files += 1
+            created_history_files += 1
         _append_history_lines(history_path, history_lines)
         appended_blocks += 1
 
         lines[sec["start"]:sec["end"]] = updated_section.splitlines()
         migrated_entries += 1
+
+    # Materialize current-state files for entries without inline history too.
+    refreshed_text = "\n".join(lines)
+    refreshed_sections = parse_sections(refreshed_text)
+    for sec in refreshed_sections:
+        entry_id = extract_id(sec["heading"])
+        if not entry_id:
+            continue
+        if is_stub(sec["heading"]) or sec["status"] == "refuted":
+            continue
+        section_text = "\n".join(lines[sec["start"]:sec["end"]])
+        current_path = infer_current_path(epistemic_path, entry_id)
+        if _write_current_state(current_path, section_text):
+            created_current_files += 1
 
     updated = "\n".join(lines)
     if original.endswith("\n"):
@@ -117,7 +156,7 @@ def externalize_epistemic_history(epistemic_path: Path) -> EpistemicHistoryMigra
 
     return EpistemicHistoryMigrationResult(
         migrated_entries=migrated_entries,
-        created_files=created_files,
+        created_history_files=created_history_files,
+        created_current_files=created_current_files,
         appended_blocks=appended_blocks,
     )
-

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -47,7 +47,7 @@ All required fields must be present.
     ## E{NNN}: {name} (believed|contested|unverified)
     **Current position:** 1-2 sentences.
     **Agent guidance:** 1 sentence only.
-    [Optional inline **History:** is allowed, but prefer external per-ID history file.]
+    [Optional inline **History:** is allowed, but prefer external per-ID files.]
 
 **Workflow registry:**
 
@@ -96,12 +96,14 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - **Be succinct.** High information density. No filler.
 - Timeline: short factual entries. What happened, why, what resulted.
 - Concept registry: structured fields only. 5 lines ideal, 10 max.
-- Epistemic state: 1-2 sentence position. History as bullet list. 1-sentence agent guidance.
+- Epistemic state: 1-2 sentence position. 1-sentence agent guidance.
 - Workflow registry: structured fields only. Context + trigger/method.
 - DEAD/refuted entries: 1-2 sentences max. Key lesson + replacement.
 - **Budget matters.** Every line stays in context for future chunks. Be ruthless about cutting words.
-- For epistemic entries, keep the main file concise. Store detailed append-only history in inferred files:
-  `{{ epistemic_history_dir }}/E{NNN}.md` (derive from entry ID; do NOT add a `History file:` field).
+- For epistemic entries, use inferred per-ID files:
+  - Mutable current state (rewrite when E{NNN} changes): `{{ epistemic_current_dir }}/E{NNN}.em`
+  - Append-only history log (append only): `{{ epistemic_history_dir }}/E{NNN}.em`
+- Keep `{{ doc_paths.epistemic }}` concise. Put detailed, coherent per-claim state in the current file.
 
 ## Important
 
@@ -110,6 +112,7 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Capture cross-concept relationships using stable IDs (C###, E###, W###).
 - Architect review comments on merged PRs = debt.
 - When two artifacts make contradictory claims, that's an epistemic entry.
+- For each touched E{NNN}, keep exactly one coherent current position (no contradictory parallel states).
 - Do NOT add entries about the fold process itself.
 - When a concept's source files are deleted, mark it DEAD.
 - When an ORPHANED CONCEPTS section is present, triage each one.

--- a/engram/templates/seed_prompt.md
+++ b/engram/templates/seed_prompt.md
@@ -32,8 +32,7 @@ Use ONLY these IDs for new entries. Do NOT invent your own.
 
     ## E{NNN}: {name} (believed|unverified)
     **Current position:** 1-2 sentences.
-    **History:**
-    - source: "claim" → status
+    **Agent guidance:** 1 sentence.
 
 **Workflows (FULL form):**
 
@@ -47,3 +46,6 @@ Use ONLY these IDs for new entries. Do NOT invent your own.
 - Focus on what exists now, not historical evolution (that comes in subsequent chunks).
 - Capture relationships between concepts using stable IDs.
 - Mark anything uncertain as (unverified) — subsequent chunks will provide evidence.
+- For each E{NNN}, maintain inferred per-ID files:
+  - mutable current state: `{{ doc_paths.epistemic | replace('.md', '') }}/current/E{NNN}.em`
+  - append-only history: `{{ doc_paths.epistemic | replace('.md', '') }}/history/E{NNN}.em`

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -91,15 +91,17 @@ git worktree remove /tmp/engram-epistemic-{{ ref_commit[:8] }}
 
 For each entry below:
 - **Confirm** if still valid. Keep status and append a fresh, claim-specific
-  history update to `{{ epistemic_history_dir }}/E{NNN}.md` for that entry ID:
+  history update to `{{ epistemic_history_dir }}/E{NNN}.em` for that entry ID:
   `- Evidence@<commit> <path>:<line>: <finding> -> believed|unverified`
+- Rewrite the mutable current-state file `{{ epistemic_current_dir }}/E{NNN}.em`
+  so it reflects one coherent, up-to-date position for the claim.
 - **Refute** if no longer true. Move to {{ doc_paths.epistemic_graveyard }} and replace with stub.
 - **Supersede** if the belief changed. Update to the current claim with clear evidence/history.
 - If no direct evidence exists for a retained belief, downgrade status (`believed` -> `contested|unverified`) or move to graveyard if refuted.
 - Do NOT use generic lines like `reaffirmed -> believed`.
 
 Do not add a `History file:` line in main epistemic entries. History file path is inferred from ID.
-Do not read per-ID history files (`{{ epistemic_history_dir }}/E*.md`) during audit.
+Do not read per-ID history files (`{{ epistemic_history_dir }}/E*.em`) during audit.
 Treat them as append-only logs: decide from main living docs + temporal worktree evidence,
 then append one concise bullet via Bash per retained claim.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,11 +123,15 @@ class TestMigrateEpistemicHistory:
         )
         assert result.exit_code == 0
         assert "Epistemic history migration complete." in result.output
+        assert "Created current files:" in result.output
+        assert "Created history files:" in result.output
         assert "Lint: PASS" in result.output
 
         updated = epistemic.read_text()
         assert "**History:**" not in updated
-        history_file = project_dir / "docs" / "decisions" / "epistemic_state" / "E005.md"
+        current_file = project_dir / "docs" / "decisions" / "epistemic_state" / "current" / "E005.em"
+        assert current_file.exists()
+        history_file = project_dir / "docs" / "decisions" / "epistemic_state" / "history" / "E005.em"
         assert history_file.exists()
 
 

--- a/tests/test_epistemic_history_migration.py
+++ b/tests/test_epistemic_history_migration.py
@@ -21,14 +21,19 @@ def test_externalizes_inline_history_into_inferred_file(tmp_path: Path) -> None:
 
     result = externalize_epistemic_history(epistemic)
     assert result.migrated_entries == 1
-    assert result.created_files == 1
+    assert result.created_history_files == 1
+    assert result.created_current_files == 1
     assert result.appended_blocks == 1
 
     updated = epistemic.read_text()
     assert "**History:**" not in updated
     assert "Ground truth annotation > voting (believed)" in updated
 
-    history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E005.md"
+    current_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E005.em"
+    assert current_file.exists()
+    assert "## E005:" in current_file.read_text()
+
+    history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E005.em"
     assert history_file.exists()
     content = history_file.read_text()
     assert "## E005:" in content
@@ -48,9 +53,12 @@ def test_migration_is_noop_when_no_inline_history(tmp_path: Path) -> None:
 
     result = externalize_epistemic_history(epistemic)
     assert result.migrated_entries == 0
-    assert result.created_files == 0
+    assert result.created_history_files == 0
+    assert result.created_current_files == 1
     assert result.appended_blocks == 0
     assert epistemic.read_text() == before
+    current_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E010.em"
+    assert current_file.exists()
 
 
 def test_bold_history_header_does_not_emit_stray_marker(tmp_path: Path) -> None:
@@ -66,7 +74,7 @@ def test_bold_history_header_does_not_emit_stray_marker(tmp_path: Path) -> None:
     )
 
     externalize_epistemic_history(epistemic)
-    history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E015.md"
+    history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E015.em"
     content = history_file.read_text()
     assert "- **" not in content
     assert "- Product Dec 12: validated" in content
@@ -92,7 +100,7 @@ def test_unknown_bold_field_after_history_is_preserved(tmp_path: Path) -> None:
     assert "**Agent guidance:** continue." in updated
     assert "**History:**" not in updated
 
-    history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E020.md"
+    history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E020.em"
     content = history_file.read_text()
     assert "2026-02-21: validated from timeline" in content
     assert "Custom note" not in content

--- a/tests/test_epistemic_history_paths.py
+++ b/tests/test_epistemic_history_paths.py
@@ -1,0 +1,30 @@
+"""Path inference helpers for split per-ID epistemic files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from engram.epistemic_history import (
+    infer_current_path,
+    infer_history_candidates,
+    infer_history_path,
+    infer_legacy_history_path,
+)
+
+
+def test_infers_split_current_and_history_paths(tmp_path: Path) -> None:
+    epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
+    assert infer_current_path(epistemic, "E005") == (
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E005.em"
+    )
+    assert infer_history_path(epistemic, "E005") == (
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E005.em"
+    )
+
+
+def test_history_candidates_include_legacy_fallback(tmp_path: Path) -> None:
+    epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
+    assert infer_history_candidates(epistemic, "E123") == [
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E123.em",
+        infer_legacy_history_path(epistemic, "E123"),
+    ]

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -281,12 +281,31 @@ Just a statement with no evidence chain.
 **Agent guidance:** keep monitoring.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
-        history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E005.md"
+        history_file = (
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E005.em"
+        )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
             "# Epistemic History\n\n"
             "## E005: externalized claim\n\n"
             "- 2026-02-21: reviewed\n",
+        )
+        assert validate_epistemic_state(doc, epistemic_path=epistemic_path) == []
+
+    def test_valid_with_inferred_current_file(self, tmp_path: Path) -> None:
+        doc = """\
+## E004: externalized current claim (believed)
+**Current position:** canonical in per-ID file.
+"""
+        epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
+        current_file = (
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E004.em"
+        )
+        current_file.parent.mkdir(parents=True, exist_ok=True)
+        current_file.write_text(
+            "## E004: externalized current claim (believed)\n"
+            "**Current position:** still believed\n"
+            "**Agent guidance:** monitor.\n",
         )
         assert validate_epistemic_state(doc, epistemic_path=epistemic_path) == []
 
@@ -298,7 +317,7 @@ Just a statement with no evidence chain.
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         violations = validate_epistemic_state(doc, epistemic_path=epistemic_path)
         assert len(violations) == 1
-        assert "inferred history file not found" in violations[0].message
+        assert "inferred epistemic files not found" in violations[0].message
 
     def test_inferred_history_file_must_match_entry_id(self, tmp_path: Path) -> None:
         doc = """\
@@ -306,7 +325,9 @@ Just a statement with no evidence chain.
 **Current position:** still believed.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
-        history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E007.md"
+        history_file = (
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E007.em"
+        )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
             "# Epistemic History\n\n"
@@ -324,7 +345,9 @@ Just a statement with no evidence chain.
 **Evidence:** carried over from prior draft
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
-        history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E008.md"
+        history_file = (
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E008.em"
+        )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
             "# Epistemic History\n\n"
@@ -343,7 +366,9 @@ Just a statement with no evidence chain.
 **Evidence:** carried over from prior draft
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
-        history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E009.md"
+        history_file = (
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E009.em"
+        )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
             "# Epistemic History\n\n"
@@ -362,7 +387,9 @@ Just a statement with no evidence chain.
 **Current position:** still believed.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
-        history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E010.md"
+        history_file = (
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E010.em"
+        )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
             "# Epistemic History\n\n"
@@ -383,7 +410,9 @@ Just a statement with no evidence chain.
 **Current position:** still believed.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
-        history_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E011.md"
+        history_file = (
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E011.em"
+        )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
             "# Epistemic History\n\n"

--- a/tests/test_temporal_orphan_triage.py
+++ b/tests/test_temporal_orphan_triage.py
@@ -459,6 +459,8 @@ class TestTriagePromptTemporalContext:
         assert "git worktree add /tmp/engram-epistemic-abc123de" in output
         assert "Evidence@<commit>" in output
         assert "Do NOT use generic lines like `reaffirmed -> believed`." in output
+        assert "/epistemic_state/history/E{NNN}.em" in output
+        assert "/epistemic_state/current/E{NNN}.em" in output
 
 
 # ==================================================================


### PR DESCRIPTION
## Summary
This PR implements the friction bundle from #67 by moving epistemic per-ID support to a split layout with mutable current state and append-only history.

### What changed
- Added split path inference helpers:
  - current: `epistemic_state/current/E###.em`
  - history: `epistemic_state/history/E###.em`
  - legacy fallback still supported: `epistemic_state/E###.md`
- Updated fold/triage/seed prompt templates and prompt renderer to teach:
  - current files are editable,
  - history files are append-only and should not be read during fold/audit rounds.
- Updated epistemic schema validation to read inferred current/history files (plus legacy fallback) and include them in evidence/audit checks.
- Updated epistemic drift staleness extraction to use dates/evidence from split current/history files.
- Updated `migrate-epistemic-history` to materialize split files:
  - writes per-ID current state files,
  - externalizes inline history into per-ID history files.

### Tests
- Updated existing tests for new `.em` split layout and messaging.
- Added helper path inference tests in `tests/test_epistemic_history_paths.py`.
- Ran full suite:
  - `source venv/bin/activate && PYTHONPATH=. python -m pytest tests/ -q`

Fixes #67
