### PR TITLE
Reduce fold friction: layout-aware prompts + lock gitignore

### DIFF
--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -89,6 +89,8 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Most information-dense items. A single sentence often encodes a major decision.
 - They reveal: intent, corrections, decisions, priorities, dead ends, rationale
 - Read as conversation threads — sequence within a session tells a story
+- Prompt lines like `[Pasted text #N +M lines]` are placeholder markers for omitted pasted blocks.
+  Treat them as "user pasted external context" signals, not literal project facts.
 - When prompts contradict docs/issues, the prompt is authoritative
 
 ## Style
@@ -100,10 +102,16 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Workflow registry: structured fields only. Context + trigger/method.
 - DEAD/refuted entries: 1-2 sentences max. Key lesson + replacement.
 - **Budget matters.** Every line stays in context for future chunks. Be ruthless about cutting words.
+{% if epistemic_layout_mode == "split" %}
 - For epistemic entries, use inferred per-ID files:
   - Mutable current state (rewrite when E{NNN} changes): `{{ epistemic_current_dir }}/E{NNN}.em`
   - Append-only history log (append only): `{{ epistemic_history_dir }}/E{NNN}.em`
 - Keep `{{ doc_paths.epistemic }}` concise. Put detailed, coherent per-claim state in the current file.
+{% else %}
+- This repo uses legacy per-ID epistemic files: `{{ epistemic_history_dir }}/E{NNN}.md`
+  (single-file current+history layout).
+- Keep using the existing legacy layout for this chunk. Do NOT create split `current/` or `history/` files.
+{% endif %}
 
 ## Important
 

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -91,17 +91,19 @@ git worktree remove /tmp/engram-epistemic-{{ ref_commit[:8] }}
 
 For each entry below:
 - **Confirm** if still valid. Keep status and append a fresh, claim-specific
-  history update to `{{ epistemic_history_dir }}/E{NNN}.em` for that entry ID:
+  history update to `{{ epistemic_history_dir }}/E{NNN}{{ epistemic_history_ext }}` for that entry ID:
   `- Evidence@<commit> <path>:<line>: <finding> -> believed|unverified`
+{% if epistemic_layout_mode == "split" %}
 - Rewrite the mutable current-state file `{{ epistemic_current_dir }}/E{NNN}.em`
   so it reflects one coherent, up-to-date position for the claim.
+{% endif %}
 - **Refute** if no longer true. Move to {{ doc_paths.epistemic_graveyard }} and replace with stub.
 - **Supersede** if the belief changed. Update to the current claim with clear evidence/history.
 - If no direct evidence exists for a retained belief, downgrade status (`believed` -> `contested|unverified`) or move to graveyard if refuted.
 - Do NOT use generic lines like `reaffirmed -> believed`.
 
 Do not add a `History file:` line in main epistemic entries. History file path is inferred from ID.
-Do not read per-ID history files (`{{ epistemic_history_dir }}/E*.em`) during audit.
+Do not read per-ID history files (`{{ epistemic_history_dir }}/{{ epistemic_history_glob }}`) during audit.
 Treat them as append-only logs: decide from main living docs + temporal worktree evidence,
 then append one concise bullet via Bash per retained claim.
 

--- a/tests/test_epistemic_history_paths.py
+++ b/tests/test_epistemic_history_paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from engram.epistemic_history import (
+    detect_epistemic_layout,
     infer_current_path,
     infer_history_candidates,
     infer_history_path,
@@ -28,3 +29,28 @@ def test_history_candidates_include_legacy_fallback(tmp_path: Path) -> None:
         tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E123.em",
         infer_legacy_history_path(epistemic, "E123"),
     ]
+
+
+def test_detect_layout_defaults_to_split(tmp_path: Path) -> None:
+    epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
+    layout = detect_epistemic_layout(epistemic)
+    assert layout.mode == "split"
+    assert layout.file_glob == "E*.em"
+    assert layout.current_dir == (
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "current"
+    )
+
+
+def test_detect_layout_uses_legacy_when_legacy_files_exist(tmp_path: Path) -> None:
+    epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
+    legacy_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E005.md"
+    legacy_file.parent.mkdir(parents=True, exist_ok=True)
+    legacy_file.write_text("## E005: legacy\n")
+
+    layout = detect_epistemic_layout(epistemic)
+    assert layout.mode == "legacy"
+    assert layout.current_dir is None
+    assert layout.file_glob == "E*.md"
+    assert layout.history_dir == (
+        tmp_path / "docs" / "decisions" / "epistemic_state"
+    )

--- a/tests/test_temporal_orphan_triage.py
+++ b/tests/test_temporal_orphan_triage.py
@@ -462,6 +462,35 @@ class TestTriagePromptTemporalContext:
         assert "/epistemic_state/history/E{NNN}.em" in output
         assert "/epistemic_state/current/E{NNN}.em" in output
 
+    def test_epistemic_audit_uses_legacy_paths_when_legacy_files_exist(self, tmp_path: Path) -> None:
+        from engram.fold.prompt import render_triage_input
+        from engram.fold.chunker import DriftReport
+
+        drift = DriftReport(
+            epistemic_audit=[{
+                "name": "E008: Harness Phase 0 completion (believed)",
+                "id": "E008",
+                "days_old": 72,
+                "last_date": "2025-12-11",
+            }],
+        )
+        doc_paths = _fake_doc_paths(tmp_path)
+        legacy = tmp_path / "docs" / "decisions" / "epistemic_state" / "E008.md"
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text("## E008: legacy\n")
+
+        output = render_triage_input(
+            drift_type="epistemic_audit",
+            drift_report=drift,
+            chunk_id=13,
+            doc_paths=doc_paths,
+            ref_commit="abc123def456789012345678901234567890abcd",
+            ref_date="2026-01-01",
+        )
+        assert "/epistemic_state/E{NNN}.md" in output
+        assert "/epistemic_state/history/E{NNN}.em" not in output
+        assert "/epistemic_state/current/E{NNN}.em" not in output
+
 
 # ==================================================================
 # 8. fold_from lifecycle — set → use → clear


### PR DESCRIPTION
## Summary
Implements the fold-friction fixes from #69 for lower-capability/background agents.

### Changes
1) Layout-aware epistemic prompt rendering
- Added `detect_epistemic_layout()` to resolve split vs legacy per-ID layout.
- Prompt/triage rendering now emits layout-accurate instructions:
  - split: `epistemic_state/current|history/E*.em`
  - legacy: `epistemic_state/E*.md`
- Legacy mode guidance now explicitly tells agents not to create split dirs unless migrating.

2) Ignore transient chunk lock files
- `engram next-chunk` now ensures `.engram/.gitignore` contains:
  - `active_chunk.yaml`
  - `active_chunk.lock`
- Prevents noisy untracked lock files in project worktrees.

3) Clarified placeholder semantics for session prompts
- Fold instructions now explicitly state `[Pasted text #N +M lines]` means omitted pasted context, not literal project facts.

### Tests
- Added/updated tests for:
  - layout detection defaults/switching
  - legacy prompt guidance
  - triage rendering under legacy layout
  - lock gitignore creation on next-chunk
  - placeholder guidance presence in fold input
- Full suite: `source venv/bin/activate && PYTHONPATH=. python -m pytest tests/ -q` (533 passed)

Fixes #69
