### PR TITLE
Enforce split-only epistemic layout and migrate legacy files

### DIFF
--- a/engram/cli.py
+++ b/engram/cli.py
@@ -560,6 +560,7 @@ def migrate_epistemic_history(project_root: str) -> None:
     click.echo(f"  Created current files: {result.created_current_files}")
     click.echo(f"  Created history files: {result.created_history_files}")
     click.echo(f"  Appended blocks: {result.appended_blocks}")
+    click.echo(f"  Migrated legacy files: {result.migrated_legacy_files}")
 
     from engram.linter import lint_from_paths
     lint_result = lint_from_paths(root, config)

--- a/engram/cli.py
+++ b/engram/cli.py
@@ -551,13 +551,15 @@ def migrate_epistemic_history(project_root: str) -> None:
     doc_paths = resolve_doc_paths(config, root)
     epistemic_path = doc_paths["epistemic"]
 
-    result = externalize_epistemic_history(epistemic_path)
+    try:
+        result = externalize_epistemic_history(epistemic_path)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
     click.echo("Epistemic history migration complete.")
     click.echo(f"  Migrated entries: {result.migrated_entries}")
     click.echo(f"  Created current files: {result.created_current_files}")
     click.echo(f"  Created history files: {result.created_history_files}")
     click.echo(f"  Appended blocks: {result.appended_blocks}")
-    click.echo(f"  Migrated legacy files: {result.migrated_legacy_files}")
 
     from engram.linter import lint_from_paths
     lint_result = lint_from_paths(root, config)

--- a/engram/cli.py
+++ b/engram/cli.py
@@ -557,6 +557,7 @@ def migrate_epistemic_history(project_root: str) -> None:
     click.echo(f"  Created current files: {result.created_current_files}")
     click.echo(f"  Created history files: {result.created_history_files}")
     click.echo(f"  Appended blocks: {result.appended_blocks}")
+    click.echo(f"  Migrated legacy files: {result.migrated_legacy_files}")
 
     from engram.linter import lint_from_paths
     lint_result = lint_from_paths(root, config)

--- a/engram/epistemic_history.py
+++ b/engram/epistemic_history.py
@@ -1,11 +1,8 @@
 """Helpers for externalized per-ID epistemic files.
 
-Preferred split layout:
+Canonical layout:
 - Mutable current state: ``<epistemic_state_stem>/current/<EID>.em``
 - Append-only history: ``<epistemic_state_stem>/history/<EID>.em``
-
-Legacy compatibility:
-- Prior layouts used ``<epistemic_state_stem>/<EID>.md`` as a single file.
 """
 
 from __future__ import annotations
@@ -42,8 +39,8 @@ _ENTRY_HEADING_RE = re.compile(r"^##\s+(E\d{3,})\b", re.IGNORECASE)
 class EpistemicLayout:
     """Resolved per-ID epistemic file layout for a project."""
 
-    mode: str  # "split" | "legacy"
-    current_dir: Path | None
+    mode: str  # always "split"
+    current_dir: Path
     history_dir: Path
     file_glob: str
     extension: str
@@ -115,56 +112,14 @@ def infer_legacy_history_path(epistemic_doc_path: Path, entry_id: str) -> Path:
 
 
 def infer_history_candidates(epistemic_doc_path: Path, entry_id: str) -> list[Path]:
-    """Return history file path candidates in preference order.
-
-    Returns:
-    1) New split history path (history/E###.em)
-    2) Legacy single-file path (E###.md)
-    """
-    primary = infer_history_path(epistemic_doc_path, entry_id)
-    legacy = infer_legacy_history_path(epistemic_doc_path, entry_id)
-    if primary == legacy:
-        return [primary]
-    return [primary, legacy]
+    """Return canonical split history path candidate(s)."""
+    return [infer_history_path(epistemic_doc_path, entry_id)]
 
 
 def detect_epistemic_layout(epistemic_doc_path: Path) -> EpistemicLayout:
-    """Detect whether project uses split or legacy per-ID epistemic files.
-
-    Detection order:
-    1) If split dirs/files are present, use split layout.
-    2) Else if legacy ``E*.md`` files are present, use legacy layout.
-    3) Else default to split layout for new projects.
-    """
-    base = infer_epistemic_dir(epistemic_doc_path)
+    """Return canonical split per-ID epistemic layout."""
     current_dir = infer_current_dir(epistemic_doc_path)
     history_dir = infer_history_dir(epistemic_doc_path)
-
-    split_present = (
-        current_dir.exists()
-        or history_dir.exists()
-        or bool(list(current_dir.glob("E*.em")))
-        or bool(list(history_dir.glob("E*.em")))
-    )
-    if split_present:
-        return EpistemicLayout(
-            mode="split",
-            current_dir=current_dir,
-            history_dir=history_dir,
-            file_glob="E*.em",
-            extension=".em",
-        )
-
-    legacy_present = bool(list(base.glob("E*.md")))
-    if legacy_present:
-        return EpistemicLayout(
-            mode="legacy",
-            current_dir=None,
-            history_dir=base,
-            file_glob="E*.md",
-            extension=".md",
-        )
-
     return EpistemicLayout(
         mode="split",
         current_dir=current_dir,

--- a/engram/epistemic_history.py
+++ b/engram/epistemic_history.py
@@ -1,8 +1,8 @@
 """Helpers for externalized per-ID epistemic files.
 
 Canonical layout:
-- Mutable current state: ``<epistemic_state_stem>/current/<EID>.em``
-- Append-only history: ``<epistemic_state_stem>/history/<EID>.em``
+- Mutable current state: ``<epistemic_state_stem>/current/<EID>.md``
+- Append-only history: ``<epistemic_state_stem>/history/<EID>.md``
 """
 
 from __future__ import annotations
@@ -88,7 +88,7 @@ def infer_history_dir(epistemic_doc_path: Path) -> Path:
 
 def infer_history_path(epistemic_doc_path: Path, entry_id: str) -> Path:
     """Return inferred append-only history file path for an epistemic entry."""
-    return infer_history_dir(epistemic_doc_path) / f"{entry_id}.em"
+    return infer_history_dir(epistemic_doc_path) / f"{entry_id}.md"
 
 
 def infer_epistemic_dir(epistemic_doc_path: Path) -> Path:
@@ -103,7 +103,7 @@ def infer_current_dir(epistemic_doc_path: Path) -> Path:
 
 def infer_current_path(epistemic_doc_path: Path, entry_id: str) -> Path:
     """Return inferred mutable current-state file path for an epistemic entry."""
-    return infer_current_dir(epistemic_doc_path) / f"{entry_id}.em"
+    return infer_current_dir(epistemic_doc_path) / f"{entry_id}.md"
 
 
 def infer_legacy_history_path(epistemic_doc_path: Path, entry_id: str) -> Path:
@@ -124,8 +124,8 @@ def detect_epistemic_layout(epistemic_doc_path: Path) -> EpistemicLayout:
         mode="split",
         current_dir=current_dir,
         history_dir=history_dir,
-        file_glob="E*.em",
-        extension=".em",
+        file_glob="E*.md",
+        extension=".md",
     )
 
 

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -24,7 +24,7 @@ from engram.epistemic_history import (
     extract_external_history_for_entry,
     extract_inline_history_lines,
     infer_current_path,
-    infer_history_candidates,
+    infer_history_path,
 )
 from engram.fold.ids import IDAllocator, estimate_new_entities
 from engram.fold.prompt import render_agent_prompt, render_chunk_input, render_triage_input
@@ -358,9 +358,10 @@ def _extract_latest_external_history_date(
         return None
 
     external_sources: list[str] = []
-    candidate_paths = [infer_current_path(epistemic_path, entry_id)] + infer_history_candidates(
-        epistemic_path, entry_id,
-    )
+    candidate_paths = [
+        infer_current_path(epistemic_path, entry_id),
+        infer_history_path(epistemic_path, entry_id),
+    ]
     seen_paths: set[str] = set()
     for path in candidate_paths:
         key = str(path)

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -160,8 +160,8 @@ def render_agent_prompt(
     epistemic_history_dir = layout_vars["epistemic_history_dir"]
     epistemic_current_dir = layout_vars["epistemic_current_dir"]
     epistemic_constraints = (
-        f"- Epistemic current-state files live under {epistemic_current_dir}/E*.em and are editable.\n"
-        f"- Do NOT read per-ID epistemic history files under {epistemic_history_dir}/E*.em.\n"
+        f"- Epistemic current-state files live under {epistemic_current_dir}/E*.md and are editable.\n"
+        f"- Do NOT read per-ID epistemic history files under {epistemic_history_dir}/E*.md.\n"
         f"  They are append-only logs; when needed, append via Bash without opening them.\n"
     )
 

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -36,11 +36,11 @@ def _stringify_paths(doc_paths: dict[str, Path]) -> dict[str, str]:
 
 
 def _epistemic_layout_template_vars(doc_paths: dict[str, Path]) -> dict[str, str]:
-    """Resolve epistemic layout vars for template/prompt rendering."""
+    """Resolve canonical split epistemic layout vars for templates/prompts."""
     layout = detect_epistemic_layout(doc_paths["epistemic"])
     return {
         "epistemic_layout_mode": layout.mode,
-        "epistemic_current_dir": str(layout.current_dir) if layout.current_dir else "",
+        "epistemic_current_dir": str(layout.current_dir),
         "epistemic_history_dir": str(layout.history_dir),
         "epistemic_history_glob": layout.file_glob,
         "epistemic_history_ext": layout.extension,
@@ -157,25 +157,13 @@ def render_agent_prompt(
         else "engram lint --project-root <project_root>"
     )
     layout_vars = _epistemic_layout_template_vars(doc_paths)
-    epistemic_mode = layout_vars["epistemic_layout_mode"]
     epistemic_history_dir = layout_vars["epistemic_history_dir"]
-    epistemic_history_glob = layout_vars["epistemic_history_glob"]
     epistemic_current_dir = layout_vars["epistemic_current_dir"]
-
-    if epistemic_mode == "legacy":
-        epistemic_constraints = (
-            f"- This project uses legacy per-ID epistemic files under "
-            f"{epistemic_history_dir}/{epistemic_history_glob}.\n"
-            f"- Do NOT create split `current/` or `history/` epistemic files unless explicitly migrating.\n"
-            f"- Do NOT read per-ID epistemic files under {epistemic_history_dir}/{epistemic_history_glob}.\n"
-            f"  They are append-only logs in this project; append via Bash without opening them.\n"
-        )
-    else:
-        epistemic_constraints = (
-            f"- Epistemic current-state files live under {epistemic_current_dir}/E*.em and are editable.\n"
-            f"- Do NOT read per-ID epistemic history files under {epistemic_history_dir}/E*.em.\n"
-            f"  They are append-only logs; when needed, append via Bash without opening them.\n"
-        )
+    epistemic_constraints = (
+        f"- Epistemic current-state files live under {epistemic_current_dir}/E*.em and are editable.\n"
+        f"- Do NOT read per-ID epistemic history files under {epistemic_history_dir}/E*.em.\n"
+        f"  They are append-only logs; when needed, append via Bash without opening them.\n"
+    )
 
     return (
         f"You are processing a knowledge fold chunk.\n"

--- a/engram/linter/schema.py
+++ b/engram/linter/schema.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from engram.epistemic_history import (
     extract_external_history_for_entry,
     infer_current_path,
-    infer_history_candidates,
+    infer_history_path,
 )
 from engram.parse import Section, extract_id, is_stub, parse_sections
 
@@ -243,9 +243,7 @@ def validate_epistemic_state(content: str, epistemic_path: Path | None = None) -
         external_violation_seen = False
 
         current_path = infer_current_path(epistemic_path, entry_id) if epistemic_path else None
-        history_paths = (
-            infer_history_candidates(epistemic_path, entry_id) if epistemic_path else []
-        )
+        history_paths = [infer_history_path(epistemic_path, entry_id)] if epistemic_path else []
 
         candidate_paths = ([current_path] if current_path else []) + history_paths
         seen_paths: set[str] = set()

--- a/engram/migrate_epistemic_history.py
+++ b/engram/migrate_epistemic_history.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from engram.epistemic_history import (
+    extract_external_history_for_entry,
     infer_current_path,
+    infer_epistemic_dir,
     infer_history_path,
     remove_inline_history,
 )
@@ -22,6 +24,7 @@ class EpistemicHistoryMigrationResult:
     created_history_files: int
     created_current_files: int
     appended_blocks: int
+    migrated_legacy_files: int
 
 
 def _extract_subject(heading: str) -> str:
@@ -98,10 +101,76 @@ def _append_history_lines(path: Path, lines: list[str]) -> None:
         fh.write("\n")
 
 
+def _append_history_block(path: Path, block_text: str) -> bool:
+    """Append a raw history block to a per-ID history file."""
+    block = block_text.strip()
+    if not block:
+        return False
+
+    text = path.read_text()
+    with open(path, "a") as fh:
+        if not text.endswith("\n"):
+            fh.write("\n")
+        fh.write(f"{block}\n\n")
+    return True
+
+
+def _migrate_legacy_history_files(
+    *,
+    epistemic_path: Path,
+    subjects_by_id: dict[str, str],
+) -> tuple[int, int, int]:
+    """Move legacy per-ID ``E*.md`` files into split history files.
+
+    Returns ``(migrated_legacy_files, created_history_files, appended_blocks)``.
+    """
+    legacy_dir = infer_epistemic_dir(epistemic_path)
+    if not legacy_dir.exists():
+        return 0, 0, 0
+
+    migrated_legacy_files = 0
+    created_history_files = 0
+    appended_blocks = 0
+
+    for legacy_path in sorted(legacy_dir.glob("E*.md")):
+        if not legacy_path.is_file():
+            continue
+        entry_id = legacy_path.stem.upper()
+        if not re.fullmatch(r"E\d{3,}", entry_id):
+            continue
+
+        try:
+            legacy_text = legacy_path.read_text()
+        except OSError:
+            continue
+
+        history_path = infer_history_path(epistemic_path, entry_id)
+        subject = subjects_by_id.get(entry_id, "claim")
+        if _ensure_history_heading(history_path, entry_id, subject):
+            created_history_files += 1
+
+        scoped = extract_external_history_for_entry(legacy_text, entry_id)
+        payload_source = scoped.strip() if scoped else legacy_text.strip()
+        payload_lines = payload_source.splitlines()
+        if payload_lines and re.match(r"^##\s+E\d{3,}\b", payload_lines[0].strip(), re.IGNORECASE):
+            payload_lines = payload_lines[1:]
+        while payload_lines and not payload_lines[0].strip():
+            payload_lines = payload_lines[1:]
+        payload = "\n".join(payload_lines).strip()
+
+        if _append_history_block(history_path, payload):
+            appended_blocks += 1
+
+        legacy_path.unlink(missing_ok=True)
+        migrated_legacy_files += 1
+
+    return migrated_legacy_files, created_history_files, appended_blocks
+
+
 def externalize_epistemic_history(epistemic_path: Path) -> EpistemicHistoryMigrationResult:
     """Split inline epistemic content into per-ID current/history inferred files."""
     if not epistemic_path.exists():
-        return EpistemicHistoryMigrationResult(0, 0, 0, 0)
+        return EpistemicHistoryMigrationResult(0, 0, 0, 0, 0)
 
     original = epistemic_path.read_text()
     sections = parse_sections(original)
@@ -111,6 +180,7 @@ def externalize_epistemic_history(epistemic_path: Path) -> EpistemicHistoryMigra
     created_history_files = 0
     created_current_files = 0
     appended_blocks = 0
+    migrated_legacy_files = 0
 
     # Iterate bottom-up to keep parse indices stable during line replacement.
     for sec in reversed(sections):
@@ -153,6 +223,21 @@ def externalize_epistemic_history(epistemic_path: Path) -> EpistemicHistoryMigra
         if _write_current_state(current_path, section_text):
             created_current_files += 1
 
+    subjects_by_id: dict[str, str] = {}
+    for sec in refreshed_sections:
+        entry_id = extract_id(sec["heading"])
+        if not entry_id:
+            continue
+        subjects_by_id[entry_id.upper()] = _extract_subject(sec["heading"])
+
+    legacy_migrated, legacy_created, legacy_appended = _migrate_legacy_history_files(
+        epistemic_path=epistemic_path,
+        subjects_by_id=subjects_by_id,
+    )
+    migrated_legacy_files += legacy_migrated
+    created_history_files += legacy_created
+    appended_blocks += legacy_appended
+
     updated = "\n".join(lines)
     if original.endswith("\n"):
         updated += "\n"
@@ -163,4 +248,5 @@ def externalize_epistemic_history(epistemic_path: Path) -> EpistemicHistoryMigra
         created_history_files=created_history_files,
         created_current_files=created_current_files,
         appended_blocks=appended_blocks,
+        migrated_legacy_files=migrated_legacy_files,
     )

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -102,16 +102,10 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Workflow registry: structured fields only. Context + trigger/method.
 - DEAD/refuted entries: 1-2 sentences max. Key lesson + replacement.
 - **Budget matters.** Every line stays in context for future chunks. Be ruthless about cutting words.
-{% if epistemic_layout_mode == "split" %}
 - For epistemic entries, use inferred per-ID files:
   - Mutable current state (rewrite when E{NNN} changes): `{{ epistemic_current_dir }}/E{NNN}.em`
   - Append-only history log (append only): `{{ epistemic_history_dir }}/E{NNN}.em`
 - Keep `{{ doc_paths.epistemic }}` concise. Put detailed, coherent per-claim state in the current file.
-{% else %}
-- This repo uses legacy per-ID epistemic files: `{{ epistemic_history_dir }}/E{NNN}.md`
-  (single-file current+history layout).
-- Keep using the existing legacy layout for this chunk. Do NOT create split `current/` or `history/` files.
-{% endif %}
 
 ## Important
 

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -103,8 +103,8 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - DEAD/refuted entries: 1-2 sentences max. Key lesson + replacement.
 - **Budget matters.** Every line stays in context for future chunks. Be ruthless about cutting words.
 - For epistemic entries, use inferred per-ID files:
-  - Mutable current state (rewrite when E{NNN} changes): `{{ epistemic_current_dir }}/E{NNN}.em`
-  - Append-only history log (append only): `{{ epistemic_history_dir }}/E{NNN}.em`
+  - Mutable current state (rewrite when E{NNN} changes): `{{ epistemic_current_dir }}/E{NNN}.md`
+  - Append-only history log (append only): `{{ epistemic_history_dir }}/E{NNN}.md`
 - Keep `{{ doc_paths.epistemic }}` concise. Put detailed, coherent per-claim state in the current file.
 
 ## Important

--- a/engram/templates/seed_prompt.md
+++ b/engram/templates/seed_prompt.md
@@ -47,5 +47,5 @@ Use ONLY these IDs for new entries. Do NOT invent your own.
 - Capture relationships between concepts using stable IDs.
 - Mark anything uncertain as (unverified) — subsequent chunks will provide evidence.
 - For each E{NNN}, maintain inferred per-ID files:
-  - mutable current state: `{{ doc_paths.epistemic | replace('.md', '') }}/current/E{NNN}.em`
-  - append-only history: `{{ doc_paths.epistemic | replace('.md', '') }}/history/E{NNN}.em`
+  - mutable current state: `{{ doc_paths.epistemic | replace('.md', '') }}/current/E{NNN}.md`
+  - append-only history: `{{ doc_paths.epistemic | replace('.md', '') }}/history/E{NNN}.md`

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -93,7 +93,7 @@ For each entry below:
 - **Confirm** if still valid. Keep status and append a fresh, claim-specific
   history update to `{{ epistemic_history_dir }}/E{NNN}{{ epistemic_history_ext }}` for that entry ID:
   `- Evidence@<commit> <path>:<line>: <finding> -> believed|unverified`
-- Rewrite the mutable current-state file `{{ epistemic_current_dir }}/E{NNN}.em`
+- Rewrite the mutable current-state file `{{ epistemic_current_dir }}/E{NNN}.md`
   so it reflects one coherent, up-to-date position for the claim.
 - **Refute** if no longer true. Move to {{ doc_paths.epistemic_graveyard }} and replace with stub.
 - **Supersede** if the belief changed. Update to the current claim with clear evidence/history.

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -93,10 +93,8 @@ For each entry below:
 - **Confirm** if still valid. Keep status and append a fresh, claim-specific
   history update to `{{ epistemic_history_dir }}/E{NNN}{{ epistemic_history_ext }}` for that entry ID:
   `- Evidence@<commit> <path>:<line>: <finding> -> believed|unverified`
-{% if epistemic_layout_mode == "split" %}
 - Rewrite the mutable current-state file `{{ epistemic_current_dir }}/E{NNN}.em`
   so it reflects one coherent, up-to-date position for the claim.
-{% endif %}
 - **Refute** if no longer true. Move to {{ doc_paths.epistemic_graveyard }} and replace with stub.
 - **Supersede** if the belief changed. Update to the current claim with clear evidence/history.
 - If no direct evidence exists for a retained belief, downgrade status (`believed` -> `contested|unverified`) or move to graveyard if refuted.

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1077,7 +1077,7 @@ class TestNextChunk:
         assert "/epistemic_state/current/E*.em" in prompt_text
         assert "/epistemic_state/history/E*.em" in prompt_text
 
-    def test_prompt_uses_legacy_epistemic_paths_when_legacy_files_present(self, project, config):
+    def test_prompt_uses_split_epistemic_paths_when_legacy_files_present(self, project, config):
         legacy = project / "docs" / "decisions" / "epistemic_state" / "E005.md"
         legacy.parent.mkdir(parents=True, exist_ok=True)
         legacy.write_text("## E005: legacy history\n")
@@ -1089,8 +1089,9 @@ class TestNextChunk:
 
         result = next_chunk(config, project)
         prompt_text = result.prompt_path.read_text()
-        assert "/epistemic_state/E*.md" in prompt_text
-        assert "/epistemic_state/current/E*.em" not in prompt_text
+        assert "/epistemic_state/current/E*.em" in prompt_text
+        assert "/epistemic_state/history/E*.em" in prompt_text
+        assert "/epistemic_state/E*.md" not in prompt_text
 
     def test_pre_assigned_ids_do_not_collide_with_existing_doc_ids(self, project, config):
         # Seed living docs with high existing IDs (simulates fresh allocator DB behind docs)

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -384,7 +384,7 @@ class TestFindClaimsByStatus:
             "**Current position:** disputed.\n"
         )
         history_file = (
-            project / "docs" / "decisions" / "epistemic_state" / "history" / "E021.em"
+            project / "docs" / "decisions" / "epistemic_state" / "history" / "E021.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -468,7 +468,7 @@ class TestFindStaleEpistemicEntries:
 
         history_dir = project / "docs" / "decisions" / "epistemic_state" / "history"
         history_dir.mkdir(parents=True, exist_ok=True)
-        (history_dir / "E087.em").write_text(
+        (history_dir / "E087.md").write_text(
             "## E087: inner structure pruning impact\n"
             f"- Evidence@{sha} docs/decisions/epistemic_state.md:1: audit update -> believed\n"
         )
@@ -493,7 +493,7 @@ class TestFindStaleEpistemicEntries:
 
         history_dir = project / "docs" / "decisions" / "epistemic_state" / "history"
         history_dir.mkdir(parents=True, exist_ok=True)
-        (history_dir / "E088.em").write_text(
+        (history_dir / "E088.md").write_text(
             "## E088: some claim\n"
             "- Evidence@deadbeef docs/decisions/epistemic_state.md:1: unknown -> believed\n"
         )
@@ -753,7 +753,7 @@ class TestFindStaleEpistemicEntries:
             "**Current position:** still believed.\n"
         )
         history_file = (
-            project / "docs" / "decisions" / "epistemic_state" / "history" / "E022.em"
+            project / "docs" / "decisions" / "epistemic_state" / "history" / "E022.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -776,7 +776,7 @@ class TestFindStaleEpistemicEntries:
             f"- {old_date}: old inline\n"
         )
         history_file = (
-            project / "docs" / "decisions" / "epistemic_state" / "history" / "E023.em"
+            project / "docs" / "decisions" / "epistemic_state" / "history" / "E023.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -798,7 +798,7 @@ class TestFindStaleEpistemicEntries:
             f"- {old_date}: stale inline\n",
         )
         current_file = (
-            project / "docs" / "decisions" / "epistemic_state" / "current" / "E089.em"
+            project / "docs" / "decisions" / "epistemic_state" / "current" / "E089.md"
         )
         current_file.parent.mkdir(parents=True, exist_ok=True)
         current_file.write_text(
@@ -819,7 +819,7 @@ class TestFindStaleEpistemicEntries:
             "**Current position:** still believed.\n"
         )
         history_file = (
-            project / "docs" / "decisions" / "epistemic_state" / "history" / "E024.em"
+            project / "docs" / "decisions" / "epistemic_state" / "history" / "E024.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -1074,8 +1074,8 @@ class TestNextChunk:
         prompt_text = result.prompt_path.read_text()
         assert "knowledge fold chunk" in prompt_text
         assert "Pre-assigned IDs for this chunk" in prompt_text
-        assert "/epistemic_state/current/E*.em" in prompt_text
-        assert "/epistemic_state/history/E*.em" in prompt_text
+        assert "/epistemic_state/current/E*.md" in prompt_text
+        assert "/epistemic_state/history/E*.md" in prompt_text
 
     def test_prompt_uses_split_epistemic_paths_when_legacy_files_present(self, project, config):
         legacy = project / "docs" / "decisions" / "epistemic_state" / "E005.md"
@@ -1089,8 +1089,8 @@ class TestNextChunk:
 
         result = next_chunk(config, project)
         prompt_text = result.prompt_path.read_text()
-        assert "/epistemic_state/current/E*.em" in prompt_text
-        assert "/epistemic_state/history/E*.em" in prompt_text
+        assert "/epistemic_state/current/E*.md" in prompt_text
+        assert "/epistemic_state/history/E*.md" in prompt_text
         assert "/epistemic_state/E*.md" not in prompt_text
 
     def test_pre_assigned_ids_do_not_collide_with_existing_doc_ids(self, project, config):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,6 +125,7 @@ class TestMigrateEpistemicHistory:
         assert "Epistemic history migration complete." in result.output
         assert "Created current files:" in result.output
         assert "Created history files:" in result.output
+        assert "Migrated legacy files:" in result.output
         assert "Lint: PASS" in result.output
 
         updated = epistemic.read_text()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,6 +125,7 @@ class TestMigrateEpistemicHistory:
         assert "Epistemic history migration complete." in result.output
         assert "Created current files:" in result.output
         assert "Created history files:" in result.output
+        assert "Migrated legacy files:" in result.output
         assert "Lint: PASS" in result.output
 
         updated = epistemic.read_text()
@@ -134,7 +135,7 @@ class TestMigrateEpistemicHistory:
         history_file = project_dir / "docs" / "decisions" / "epistemic_state" / "history" / "E005.md"
         assert history_file.exists()
 
-    def test_fails_with_legacy_per_id_files(self, runner: CliRunner, project_dir: Path) -> None:
+    def test_migrates_legacy_per_id_files(self, runner: CliRunner, project_dir: Path) -> None:
         init_result = runner.invoke(cli, ["init", "--project-root", str(project_dir)])
         assert init_result.exit_code == 0
 
@@ -146,10 +147,11 @@ class TestMigrateEpistemicHistory:
             cli,
             ["migrate-epistemic-history", "--project-root", str(project_dir)],
         )
-        assert result.exit_code != 0
-        assert "Legacy epistemic files found under the deprecated path." in result.output
-        assert "Move files from" in result.output
-        assert "history/E*.md" in result.output
+        assert result.exit_code == 0
+        assert "Migrated legacy files: 1" in result.output
+        migrated = project_dir / "docs" / "decisions" / "epistemic_state" / "history" / "E005.md"
+        assert migrated.exists()
+        assert not legacy_file.exists()
 
 
 class TestActiveChunkLock:

--- a/tests/test_epistemic_history_paths.py
+++ b/tests/test_epistemic_history_paths.py
@@ -15,17 +15,17 @@ from engram.epistemic_history import (
 def test_infers_split_current_and_history_paths(tmp_path: Path) -> None:
     epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
     assert infer_current_path(epistemic, "E005") == (
-        tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E005.em"
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E005.md"
     )
     assert infer_history_path(epistemic, "E005") == (
-        tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E005.em"
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E005.md"
     )
 
 
 def test_history_candidates_include_legacy_fallback(tmp_path: Path) -> None:
     epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
     assert infer_history_candidates(epistemic, "E123") == [
-        tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E123.em",
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E123.md",
     ]
 
 
@@ -33,7 +33,7 @@ def test_detect_layout_defaults_to_split(tmp_path: Path) -> None:
     epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
     layout = detect_epistemic_layout(epistemic)
     assert layout.mode == "split"
-    assert layout.file_glob == "E*.em"
+    assert layout.file_glob == "E*.md"
     assert layout.current_dir == (
         tmp_path / "docs" / "decisions" / "epistemic_state" / "current"
     )
@@ -50,7 +50,7 @@ def test_detect_layout_stays_split_even_when_legacy_files_exist(tmp_path: Path) 
     assert layout.current_dir == (
         tmp_path / "docs" / "decisions" / "epistemic_state" / "current"
     )
-    assert layout.file_glob == "E*.em"
+    assert layout.file_glob == "E*.md"
     assert layout.history_dir == (
         tmp_path / "docs" / "decisions" / "epistemic_state" / "history"
     )

--- a/tests/test_epistemic_history_paths.py
+++ b/tests/test_epistemic_history_paths.py
@@ -9,7 +9,6 @@ from engram.epistemic_history import (
     infer_current_path,
     infer_history_candidates,
     infer_history_path,
-    infer_legacy_history_path,
 )
 
 
@@ -27,7 +26,6 @@ def test_history_candidates_include_legacy_fallback(tmp_path: Path) -> None:
     epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
     assert infer_history_candidates(epistemic, "E123") == [
         tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E123.em",
-        infer_legacy_history_path(epistemic, "E123"),
     ]
 
 
@@ -41,16 +39,18 @@ def test_detect_layout_defaults_to_split(tmp_path: Path) -> None:
     )
 
 
-def test_detect_layout_uses_legacy_when_legacy_files_exist(tmp_path: Path) -> None:
+def test_detect_layout_stays_split_even_when_legacy_files_exist(tmp_path: Path) -> None:
     epistemic = tmp_path / "docs" / "decisions" / "epistemic_state.md"
     legacy_file = tmp_path / "docs" / "decisions" / "epistemic_state" / "E005.md"
     legacy_file.parent.mkdir(parents=True, exist_ok=True)
     legacy_file.write_text("## E005: legacy\n")
 
     layout = detect_epistemic_layout(epistemic)
-    assert layout.mode == "legacy"
-    assert layout.current_dir is None
-    assert layout.file_glob == "E*.md"
+    assert layout.mode == "split"
+    assert layout.current_dir == (
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "current"
+    )
+    assert layout.file_glob == "E*.em"
     assert layout.history_dir == (
-        tmp_path / "docs" / "decisions" / "epistemic_state"
+        tmp_path / "docs" / "decisions" / "epistemic_state" / "history"
     )

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -282,7 +282,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         history_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E005.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E005.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -299,7 +299,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         current_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E004.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E004.md"
         )
         current_file.parent.mkdir(parents=True, exist_ok=True)
         current_file.write_text(
@@ -318,7 +318,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         current_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E012.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "current" / "E012.md"
         )
         current_file.parent.mkdir(parents=True, exist_ok=True)
         current_file.write_text(
@@ -347,7 +347,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         history_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E007.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E007.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -365,7 +365,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         history_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E013.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E013.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -385,7 +385,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         history_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E008.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E008.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -406,7 +406,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         history_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E009.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E009.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -427,7 +427,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         history_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E010.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E010.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(
@@ -450,7 +450,7 @@ Just a statement with no evidence chain.
 """
         epistemic_path = tmp_path / "docs" / "decisions" / "epistemic_state.md"
         history_file = (
-            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E011.em"
+            tmp_path / "docs" / "decisions" / "epistemic_state" / "history" / "E011.md"
         )
         history_file.parent.mkdir(parents=True, exist_ok=True)
         history_file.write_text(

--- a/tests/test_temporal_orphan_triage.py
+++ b/tests/test_temporal_orphan_triage.py
@@ -459,8 +459,8 @@ class TestTriagePromptTemporalContext:
         assert "git worktree add /tmp/engram-epistemic-abc123de" in output
         assert "Evidence@<commit>" in output
         assert "Do NOT use generic lines like `reaffirmed -> believed`." in output
-        assert "/epistemic_state/history/E{NNN}.em" in output
-        assert "/epistemic_state/current/E{NNN}.em" in output
+        assert "/epistemic_state/history/E{NNN}.md" in output
+        assert "/epistemic_state/current/E{NNN}.md" in output
 
     def test_epistemic_audit_uses_split_paths_even_when_legacy_files_exist(self, tmp_path: Path) -> None:
         from engram.fold.prompt import render_triage_input
@@ -487,8 +487,8 @@ class TestTriagePromptTemporalContext:
             ref_commit="abc123def456789012345678901234567890abcd",
             ref_date="2026-01-01",
         )
-        assert "/epistemic_state/history/E{NNN}.em" in output
-        assert "/epistemic_state/current/E{NNN}.em" in output
+        assert "/epistemic_state/history/E{NNN}.md" in output
+        assert "/epistemic_state/current/E{NNN}.md" in output
         assert "/epistemic_state/E{NNN}.md" not in output
 
 

--- a/tests/test_temporal_orphan_triage.py
+++ b/tests/test_temporal_orphan_triage.py
@@ -462,7 +462,7 @@ class TestTriagePromptTemporalContext:
         assert "/epistemic_state/history/E{NNN}.em" in output
         assert "/epistemic_state/current/E{NNN}.em" in output
 
-    def test_epistemic_audit_uses_legacy_paths_when_legacy_files_exist(self, tmp_path: Path) -> None:
+    def test_epistemic_audit_uses_split_paths_even_when_legacy_files_exist(self, tmp_path: Path) -> None:
         from engram.fold.prompt import render_triage_input
         from engram.fold.chunker import DriftReport
 
@@ -487,9 +487,9 @@ class TestTriagePromptTemporalContext:
             ref_commit="abc123def456789012345678901234567890abcd",
             ref_date="2026-01-01",
         )
-        assert "/epistemic_state/E{NNN}.md" in output
-        assert "/epistemic_state/history/E{NNN}.em" not in output
-        assert "/epistemic_state/current/E{NNN}.em" not in output
+        assert "/epistemic_state/history/E{NNN}.em" in output
+        assert "/epistemic_state/current/E{NNN}.em" in output
+        assert "/epistemic_state/E{NNN}.md" not in output
 
 
 # ==================================================================


### PR DESCRIPTION
## Summary
- remove legacy `epistemic_state/E*.md` fallback behavior from fold prompts, chunker inputs, linter checks, and layout detection
- make split layout (`epistemic_state/current/*.em` + `epistemic_state/history/*.em`) the only runtime path for fold + triage flows
- extend `migrate-epistemic-history` to migrate existing legacy `E*.md` files into split history files, then delete legacy files
- update tests to assert split-only behavior and verify legacy migration output/CLI reporting

## Validation
- `source venv/bin/activate && PYTHONPATH=. python -m pytest tests/test_epistemic_history_paths.py tests/test_chunker.py tests/test_temporal_orphan_triage.py tests/test_epistemic_history_migration.py tests/test_cli.py -q`
- `source venv/bin/activate && PYTHONPATH=. python -m pytest tests/ -q`

Fixes #71
