### PR TITLE
Enforce input-only guardrails in fold prompts

### DIFF
--- a/engram/bootstrap/fold.py
+++ b/engram/bootstrap/fold.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from engram.config import load_config, resolve_doc_paths
 from engram.dispatch import invoke_agent, read_docs
-from engram.fold.chunker import ChunkResult, next_chunk
+from engram.fold.chunker import ChunkResult, cleanup_chunk_context_worktree, next_chunk
 from engram.fold.queue import build_queue
 from engram.linter import lint_post_dispatch
 from engram.server.briefing import regenerate_l0_briefing
@@ -172,7 +172,10 @@ def forward_fold(
             chunk.date_range or "drift triage",
         )
 
-        success = _dispatch_and_validate(config, project_root, chunk)
+        try:
+            success = _dispatch_and_validate(config, project_root, chunk)
+        finally:
+            cleanup_chunk_context_worktree(project_root, chunk.context_worktree_path)
         if success:
             log.info("Chunk %d committed", chunk.chunk_id)
         else:

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -79,7 +79,7 @@ _QUEUE_TEXT_CACHE: OrderedDict[tuple[str, str, int, int], str] = OrderedDict()
 # Evidence bullets in external epistemic history files.
 _EVIDENCE_COMMIT_RE = re.compile(r"Evidence@([0-9a-fA-F]{7,40})")
 _EVIDENCE_COMMIT_DATE_CACHE: dict[tuple[str, str], datetime | None] = {}
-_CHUNK_WORKTREE_NAME_RE = re.compile(r"^engram-chunk-\d{3}-[0-9a-f]{8}-[A-Za-z0-9._-]+$")
+_CHUNK_WORKTREE_NAME_RE = re.compile(r"^engram-chunk-\d{3,}-[0-9a-f]{8}-[A-Za-z0-9._-]+$")
 
 
 @dataclass

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -79,6 +79,7 @@ _QUEUE_TEXT_CACHE: OrderedDict[tuple[str, str, int, int], str] = OrderedDict()
 # Evidence bullets in external epistemic history files.
 _EVIDENCE_COMMIT_RE = re.compile(r"Evidence@([0-9a-fA-F]{7,40})")
 _EVIDENCE_COMMIT_DATE_CACHE: dict[tuple[str, str], datetime | None] = {}
+_CHUNK_WORKTREE_NAME_RE = re.compile(r"^engram-chunk-\d{3}-[0-9a-f]{8}-[A-Za-z0-9._-]+$")
 
 
 @dataclass
@@ -299,6 +300,9 @@ def cleanup_chunk_context_worktree(project_root: Path, worktree_path: Path | Non
         resolved.relative_to(temp_root_resolved)
     except ValueError:
         log.warning("Refusing to remove non-temp context worktree path: %s", worktree_path)
+        return
+    if not _CHUNK_WORKTREE_NAME_RE.fullmatch(resolved.name):
+        log.warning("Refusing to remove non-engram context worktree path: %s", worktree_path)
         return
 
     try:
@@ -1110,6 +1114,7 @@ def next_chunk(
         prompt_content = render_agent_prompt(
             chunk_id=chunk_id,
             date_range=drift_type,
+            chunk_type=drift_type,
             input_path=input_path,
             doc_paths=doc_paths,
             project_root=project_root,
@@ -1227,6 +1232,7 @@ def next_chunk(
     prompt_content = render_agent_prompt(
         chunk_id=chunk_id,
         date_range=date_range,
+        chunk_type="fold",
         input_path=input_path,
         doc_paths=doc_paths,
         project_root=project_root,

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -172,6 +172,8 @@ def render_agent_prompt(
         f"- Do NOT use the Task tool or spawn sub-agents. Do all work directly.\n"
         f"- Do NOT use Write to overwrite entire files. Use Edit for surgical updates only.\n"
         f"- Be SUCCINCT. High information density, no filler, no narrative prose.\n"
+        f"- For standard fold/workflow_synthesis chunks, use only the input file + living docs.\n"
+        f"- Do NOT inspect source code/git/filesystem unless the input explicitly requires special triage verification.\n"
         f"{epistemic_constraints}"
         f"\n"
         f"Read the input file at {input_path.resolve()} — it contains system instructions\n"

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -54,6 +54,8 @@ def render_chunk_input(
     items_content: str,
     pre_assigned_ids: dict[str, list[str]],
     doc_paths: dict[str, Path],
+    context_worktree_path: Path | None = None,
+    context_commit: str | None = None,
 ) -> str:
     """Render a normal fold chunk's input.md file.
 
@@ -68,6 +70,8 @@ def render_chunk_input(
         doc_paths=_stringify_paths(doc_paths),
         **layout_vars,
         pre_assigned_ids=pre_assigned_ids,
+        context_worktree_path=str(context_worktree_path) if context_worktree_path else None,
+        context_commit=context_commit,
     )
 
     content = instructions
@@ -87,6 +91,8 @@ def render_triage_input(
     ref_commit: str | None = None,
     ref_date: str | None = None,
     project_root: Path | None = None,
+    context_worktree_path: Path | None = None,
+    context_commit: str | None = None,
 ) -> str:
     """Render a drift-triage chunk's input.md file.
 
@@ -127,6 +133,8 @@ def render_triage_input(
         ref_commit=ref_commit,
         ref_date=ref_date,
         lint_cmd=lint_cmd,
+        context_worktree_path=str(context_worktree_path) if context_worktree_path else None,
+        context_commit=context_commit,
     )
 
 
@@ -137,6 +145,8 @@ def render_agent_prompt(
     input_path: Path,
     doc_paths: dict[str, Path],
     project_root: Path | None = None,
+    context_worktree_path: Path | None = None,
+    context_commit: str | None = None,
 ) -> str:
     """Render the chunk_NNN_prompt.txt agent execution prompt.
 
@@ -164,6 +174,21 @@ def render_agent_prompt(
         f"- Do NOT read per-ID epistemic history files under {epistemic_history_dir}/E*.md.\n"
         f"  They are append-only logs; when needed, append via Bash without opening them.\n"
     )
+    context_path_text = str(context_worktree_path.resolve()) if context_worktree_path else None
+    context_commit_short = context_commit[:12] if context_commit else None
+    if context_path_text:
+        repo_scope_constraints = (
+            "- Prefer input + living docs first; inspect code only when needed to disambiguate.\n"
+            f"- If inspecting repo files, use ONLY the chunk context checkout at {context_path_text}"
+            + (f" (commit `{context_commit_short}`)." if context_commit_short else ".")
+            + "\n"
+            "- Do NOT inspect source files from the project root workspace for this chunk.\n"
+        )
+    else:
+        repo_scope_constraints = (
+            "- For standard fold/workflow_synthesis chunks, use only the input file + living docs.\n"
+            "- Do NOT inspect source code/git/filesystem unless the input explicitly requires special triage verification.\n"
+        )
 
     return (
         f"You are processing a knowledge fold chunk.\n"
@@ -172,8 +197,7 @@ def render_agent_prompt(
         f"- Do NOT use the Task tool or spawn sub-agents. Do all work directly.\n"
         f"- Do NOT use Write to overwrite entire files. Use Edit for surgical updates only.\n"
         f"- Be SUCCINCT. High information density, no filler, no narrative prose.\n"
-        f"- For standard fold/workflow_synthesis chunks, use only the input file + living docs.\n"
-        f"- Do NOT inspect source code/git/filesystem unless the input explicitly requires special triage verification.\n"
+        f"{repo_scope_constraints}"
         f"{epistemic_constraints}"
         f"\n"
         f"Read the input file at {input_path.resolve()} — it contains system instructions\n"

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -191,7 +191,7 @@ def render_agent_prompt(
         repo_scope_constraints = (
             "- Use this chunk's input + living docs first.\n"
             "- Repo inspection is allowed for this triage chunk only when needed.\n"
-            "- If no chunk context checkout is provided, inspect only this workspace.\n"
+            "- Follow triage input instructions for the correct repo view (e.g., temporal worktree when provided).\n"
         )
     elif context_path_text:
         repo_scope_constraints = (

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -112,8 +112,13 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Use Edit for surgical updates. Do NOT reproduce entire documents.
 - Only edit sections affected by new content.
 - Capture cross-concept relationships using stable IDs (C###, E###, W###).
+{% if context_worktree_path %}
+- If you inspect repo files, use ONLY `{{ context_worktree_path }}`{% if context_commit %} (commit `{{ context_commit[:12] }}`){% endif %}.
+- Do NOT inspect source files from the project-root workspace for this chunk.
+{% else %}
 - For normal fold chunks, use ONLY this input file + the 4 living docs.
 - Do NOT inspect source code, git history, or filesystem state to verify claims.
+{% endif %}
 - Architect review comments on merged PRs = debt.
 - When two artifacts make contradictory claims, that's an epistemic entry.
 - For each touched E{NNN}, keep exactly one coherent current position (no contradictory parallel states).

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -112,10 +112,12 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Use Edit for surgical updates. Do NOT reproduce entire documents.
 - Only edit sections affected by new content.
 - Capture cross-concept relationships using stable IDs (C###, E###, W###).
+- For normal fold chunks, use ONLY this input file + the 4 living docs.
+- Do NOT inspect source code, git history, or filesystem state to verify claims.
 - Architect review comments on merged PRs = debt.
 - When two artifacts make contradictory claims, that's an epistemic entry.
 - For each touched E{NNN}, keep exactly one coherent current position (no contradictory parallel states).
 - Do NOT add entries about the fold process itself.
-- When a concept's source files are deleted, mark it DEAD.
+- If this input explicitly states a concept's source files were deleted, mark it DEAD.
 - When an ORPHANED CONCEPTS section is present, triage each one.
-- Treat repo paths as case-sensitive. Do not copy paths from issues/comments into living docs unless you are confident the casing matches the repo. If unsure, omit the path or use the repo-canonical casing already used elsewhere.
+- If content is ambiguous or contradictory and cannot be resolved from this input, record/maintain the uncertainty in epistemic state (e.g., contested) rather than self-verifying from repo code.

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -113,8 +113,9 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Only edit sections affected by new content.
 - Capture cross-concept relationships using stable IDs (C###, E###, W###).
 {% if context_worktree_path %}
-- If you inspect repo files, use ONLY `{{ context_worktree_path }}`{% if context_commit %} (commit `{{ context_commit[:12] }}`){% endif %}.
-- Do NOT inspect source files from the project-root workspace for this chunk.
+- For normal fold chunks, use ONLY this input file + the 4 living docs.
+- Do NOT inspect source code, git history, or filesystem state to verify claims.
+- A chunk context checkout exists at `{{ context_worktree_path }}`{% if context_commit %} (commit `{{ context_commit[:12] }}`){% endif %} for future triage-only verification.
 {% else %}
 - For normal fold chunks, use ONLY this input file + the 4 living docs.
 - Do NOT inspect source code, git history, or filesystem state to verify claims.

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -12,6 +12,15 @@ Graveyard files (append-only):
 - {{ doc_paths.concept_graveyard }}
 - {{ doc_paths.epistemic_graveyard }}
 
+{% if context_worktree_path %}
+## Chunk Context Checkout
+
+If you inspect repo files for this chunk, use ONLY:
+- `{{ context_worktree_path }}`{% if context_commit %} (commit `{{ context_commit[:12] }}`){% endif %}
+
+Do NOT inspect source files from the project-root workspace.
+{% endif %}
+
 ---
 
 {% if drift_type == "orphan_triage" %}
@@ -47,7 +56,9 @@ is never a valid reason to skip triage. For each one:
 
 Living docs are current through **{{ ref_date }}** (commit `{{ ref_commit[:12] }}`).
 Check file existence at that commit, NOT today's filesystem.
-
+{% if context_worktree_path %}
+Use the chunk context checkout above for verification.
+{% else %}
 To inspect files at the reference point:
 ```
 git worktree add /tmp/engram-triage-{{ ref_commit[:8] }} {{ ref_commit }}
@@ -57,6 +68,7 @@ Check paths in that worktree. When done:
 ```
 git worktree remove /tmp/engram-triage-{{ ref_commit[:8] }}
 ```
+{% endif %}
 
 If a file exists at that commit but is missing today, it was renamed/moved AFTER
 the date living docs know about — leave it ACTIVE. The fold will process the
@@ -76,7 +88,9 @@ and have not been referenced by recent queue items.
 
 Living docs are current through **{{ ref_date }}** (commit `{{ ref_commit[:12] }}`).
 Validate each belief against code/docs at that commit, NOT today's workspace state.
-
+{% if context_worktree_path %}
+Use the chunk context checkout above to verify whether claims were valid as of the fold context.
+{% else %}
 To inspect the project at that reference point:
 ```
 git worktree add /tmp/engram-epistemic-{{ ref_commit[:8] }} {{ ref_commit }}
@@ -87,6 +101,7 @@ When done:
 ```
 git worktree remove /tmp/engram-epistemic-{{ ref_commit[:8] }}
 ```
+{% endif %}
 {% endif %}
 
 For each entry below:
@@ -161,13 +176,20 @@ For each cluster of related workflows:
 
 Input-only mode for this chunk:
 - Use ONLY this input file + the listed living docs.
+{% if context_worktree_path %}
+- If repo inspection is needed to break a tie, use ONLY the chunk context checkout above.
+{% else %}
 - Do NOT inspect source code, git history, or filesystem state.
+{% endif %}
 {% endif %}
 
 {% if drift_type == "orphan_triage" or drift_type == "epistemic_audit" %}
 Special-case scope:
-- Repo inspection is allowed only when explicitly instructed in the reference-context block.
-- Outside that scope, stay input-only + living-doc focused.
+{% if context_worktree_path %}
+- Repo inspection is allowed for triage, but only in the chunk context checkout.
+{% else %}
+- Repo inspection is allowed for triage in this workspace (no context checkout available).
+{% endif %}
 {% endif %}
 
 ---

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -176,11 +176,7 @@ For each cluster of related workflows:
 
 Input-only mode for this chunk:
 - Use ONLY this input file + the listed living docs.
-{% if context_worktree_path %}
-- If repo inspection is needed to break a tie, use ONLY the chunk context checkout above.
-{% else %}
 - Do NOT inspect source code, git history, or filesystem state.
-{% endif %}
 {% endif %}
 
 {% if drift_type == "orphan_triage" or drift_type == "epistemic_audit" %}

--- a/engram/templates/triage_prompt.md
+++ b/engram/templates/triage_prompt.md
@@ -158,6 +158,16 @@ For each cluster of related workflows:
 {% endfor %}
 
 ({{ entry_count }} workflow entries to review for synthesis)
+
+Input-only mode for this chunk:
+- Use ONLY this input file + the listed living docs.
+- Do NOT inspect source code, git history, or filesystem state.
+{% endif %}
+
+{% if drift_type == "orphan_triage" or drift_type == "epistemic_audit" %}
+Special-case scope:
+- Repo inspection is allowed only when explicitly instructed in the reference-context block.
+- Outside that scope, stay input-only + living-doc focused.
 {% endif %}
 
 ---

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1079,7 +1079,7 @@ class TestNextChunk:
         assert "knowledge fold chunk" in prompt_text
         assert "Pre-assigned IDs for this chunk" in prompt_text
         assert "For standard fold/workflow_synthesis chunks, use only the input file + living docs." in prompt_text
-        assert "Do NOT inspect source code/git/filesystem unless the input explicitly requires special triage verification." in prompt_text
+        assert "Do NOT inspect source code/git/filesystem for this chunk." in prompt_text
         assert "/epistemic_state/current/E*.md" in prompt_text
         assert "/epistemic_state/history/E*.md" in prompt_text
 
@@ -1111,7 +1111,8 @@ class TestNextChunk:
 
         prompt_text = result.prompt_path.read_text()
         assert str(result.context_worktree_path) in prompt_text
-        assert "Do NOT inspect source files from the project root workspace for this chunk." in prompt_text
+        assert "Do NOT inspect source code/git/filesystem for this chunk." in prompt_text
+        assert "ignore it unless a future triage chunk explicitly requires repo verification." in prompt_text
 
         cleanup_chunk_context_worktree(project, result.context_worktree_path)
         assert not result.context_worktree_path.exists()

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1067,6 +1067,8 @@ class TestNextChunk:
         input_text = result.input_path.read_text()
         assert "# Instructions" in input_text
         assert "Pre-assigned IDs for this chunk" in input_text
+        assert "For normal fold chunks, use ONLY this input file + the 4 living docs." in input_text
+        assert "Do NOT inspect source code, git history, or filesystem state to verify claims." in input_text
         assert "[Pasted text #N +M lines]" in input_text
         assert "Content for the chunk." in input_text
 
@@ -1074,6 +1076,8 @@ class TestNextChunk:
         prompt_text = result.prompt_path.read_text()
         assert "knowledge fold chunk" in prompt_text
         assert "Pre-assigned IDs for this chunk" in prompt_text
+        assert "For standard fold/workflow_synthesis chunks, use only the input file + living docs." in prompt_text
+        assert "Do NOT inspect source code/git/filesystem unless the input explicitly requires special triage verification." in prompt_text
         assert "/epistemic_state/current/E*.md" in prompt_text
         assert "/epistemic_state/history/E*.md" in prompt_text
 
@@ -1201,8 +1205,11 @@ class TestNextChunk:
         r1 = next_chunk(config, project)
         assert r1.chunk_type == "workflow_synthesis"
         assert r1.drift_entry_count == 4
-        assert "W001" in r1.input_path.read_text()
-        assert ")\n- **W002" in r1.input_path.read_text()
+        workflow_text = r1.input_path.read_text()
+        assert "W001" in workflow_text
+        assert ")\n- **W002" in workflow_text
+        assert "Input-only mode for this chunk:" in workflow_text
+        assert "Do NOT inspect source code, git history, or filesystem state." in workflow_text
 
         # Second call: unchanged registry triggers cooldown suppression, so we proceed with a normal fold chunk.
         r2 = next_chunk(config, project)

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1199,6 +1199,8 @@ class TestNextChunk:
         input_text = result.input_path.read_text()
         assert "Orphan Triage Round" in input_text
         assert "orphan_0" in input_text
+        prompt_text = result.prompt_path.read_text()
+        assert "Follow triage input instructions for the correct repo view" in prompt_text
 
     def test_epistemic_audit_chunk(self, project, config):
         epistemic = project / "docs" / "decisions" / "epistemic_state.md"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import tempfile
 from types import SimpleNamespace
 from pathlib import Path
 
@@ -257,6 +258,30 @@ class TestActiveChunkLock:
 
         generation_lock = project_dir / ".engram" / "active_chunk.lock"
         assert not generation_lock.exists()
+
+    def test_clear_active_chunk_removes_context_worktree(self, runner: CliRunner, project_dir: Path) -> None:
+        init_result = runner.invoke(cli, ["init", "--project-root", str(project_dir)])
+        assert init_result.exit_code == 0
+
+        context_dir = Path(tempfile.mkdtemp(prefix="engram-chunk-test-"))
+        (context_dir / "marker.txt").write_text("x")
+
+        lock_path = project_dir / ".engram" / "active_chunk.yaml"
+        lock_path.write_text(
+            yaml.safe_dump(
+                {
+                    "chunk_id": 1,
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "context_worktree_path": str(context_dir),
+                },
+                sort_keys=True,
+            ),
+        )
+
+        result = runner.invoke(cli, ["clear-active-chunk", "--project-root", str(project_dir)])
+        assert result.exit_code == 0
+        assert not lock_path.exists()
+        assert not context_dir.exists()
 
     def test_generation_lock_is_held_during_next_chunk(self, runner: CliRunner, project_dir: Path, monkeypatch) -> None:
         init_result = runner.invoke(cli, ["init", "--project-root", str(project_dir)])

--- a/tests/test_temporal_orphan_triage.py
+++ b/tests/test_temporal_orphan_triage.py
@@ -385,7 +385,7 @@ class TestTriagePromptTemporalContext:
         )
         assert "Temporal Context" not in output
         assert "Special-case scope:" in output
-        assert "Repo inspection is allowed only when explicitly instructed in the reference-context block." in output
+        assert "Repo inspection is allowed for triage in this workspace" in output
 
     def test_temporal_block_with_ref_commit(self, tmp_path: Path) -> None:
         from engram.fold.prompt import render_triage_input
@@ -408,6 +408,30 @@ class TestTriagePromptTemporalContext:
         assert "2026-01-01" in output
         assert "abc123def456" in output
         assert "git worktree add" in output
+
+    def test_temporal_block_uses_provided_context_worktree(self, tmp_path: Path) -> None:
+        from engram.fold.prompt import render_triage_input
+        from engram.fold.chunker import DriftReport
+
+        drift = DriftReport(
+            orphaned_concepts=[{"name": "C001: Widget", "id": "C001", "paths": ["src/w.py"]}],
+        )
+        doc_paths = _fake_doc_paths(tmp_path)
+
+        output = render_triage_input(
+            drift_type="orphan_triage",
+            drift_report=drift,
+            chunk_id=1,
+            doc_paths=doc_paths,
+            ref_commit="abc123def456789012345678901234567890abcd",
+            ref_date="2026-01-01",
+            context_worktree_path=Path("/tmp/engram-chunk-001-abc123de-demo"),
+            context_commit="abc123def456789012345678901234567890abcd",
+        )
+        assert "Chunk Context Checkout" in output
+        assert "/tmp/engram-chunk-001-abc123de-demo" in output
+        assert "git worktree add" not in output
+        assert "Repo inspection is allowed for triage, but only in the chunk context checkout." in output
 
     def test_temporal_block_not_in_contested_review(self, tmp_path: Path) -> None:
         """Temporal context does not appear in contested review."""

--- a/tests/test_temporal_orphan_triage.py
+++ b/tests/test_temporal_orphan_triage.py
@@ -384,6 +384,8 @@ class TestTriagePromptTemporalContext:
             doc_paths=doc_paths,
         )
         assert "Temporal Context" not in output
+        assert "Special-case scope:" in output
+        assert "Repo inspection is allowed only when explicitly instructed in the reference-context block." in output
 
     def test_temporal_block_with_ref_commit(self, tmp_path: Path) -> None:
         from engram.fold.prompt import render_triage_input
@@ -454,6 +456,7 @@ class TestTriagePromptTemporalContext:
             ref_date="2026-01-01",
         )
         assert "Temporal Context" in output
+        assert "Special-case scope:" in output
         assert "2026-01-01" in output
         assert "abc123def456" in output
         assert "git worktree add /tmp/engram-epistemic-abc123de" in output


### PR DESCRIPTION
## Summary
- Enforces input-only behavior for normal fold processing by updating prompt templates and agent prompt constraints.
- Keeps repo inspection available only for special triage contexts where explicitly instructed.
- Removes guidance that encouraged normal fold agents to infer DEAD status by checking current filesystem state.

## Changes
- `engram/templates/fold_prompt.md`
  - Added explicit guardrails: normal fold chunks must use only input + living docs.
  - Explicitly forbids source/git/filesystem verification during normal folds.
  - Reworded deletion guidance to require explicit statement in input.
- `engram/templates/triage_prompt.md`
  - Added input-only guardrails for `workflow_synthesis` triage chunks.
  - Added narrow special-case note for `orphan_triage` and `epistemic_audit`.
- `engram/fold/prompt.py`
  - Added top-level agent prompt constraints mirroring input-only guardrails.

## Tests
- `PYTHONPATH=. python -m pytest tests/test_chunker.py::TestNextChunk::test_normal_chunk tests/test_chunker.py::TestNextChunk::test_workflow_synthesis_not_repeated_for_same_ids tests/test_temporal_orphan_triage.py::TestTriagePromptTemporalContext::test_no_temporal_block_without_ref_commit tests/test_temporal_orphan_triage.py::TestTriagePromptTemporalContext::test_epistemic_audit_includes_evidence_gate_instructions -v`
