### PR TITLE
Reduce new-E scaffolding friction in fold prompts/lint

### DIFF
--- a/engram/linter/schema.py
+++ b/engram/linter/schema.py
@@ -302,6 +302,24 @@ def validate_epistemic_state(content: str, epistemic_path: Path | None = None) -
                 continue
 
             preferred_history = history_paths[0] if history_paths else None
+            remediation = ""
+            if current_path and preferred_history:
+                remediation = (
+                    " Remediation: create/update both files with matching heading "
+                    f"for {entry_id} and support content (Evidence/History): "
+                    f"current={current_path}, history={preferred_history}"
+                )
+            elif preferred_history:
+                remediation = (
+                    " Remediation: create/update inferred history file with matching "
+                    f"heading for {entry_id} and support content: {preferred_history}"
+                )
+            elif current_path:
+                remediation = (
+                    " Remediation: create/update inferred current-state file with matching "
+                    f"heading for {entry_id} and support content: {current_path}"
+                )
+
             if not external_file_seen:
                 if preferred_history and current_path:
                     missing_msg = (
@@ -335,7 +353,7 @@ def validate_epistemic_state(content: str, epistemic_path: Path | None = None) -
                         "Missing inline 'Evidence:'/'History:' and inferred epistemic files "
                         "lack support content"
                     )
-            violations.append(Violation("epistemic", entry_id, missing_msg))
+            violations.append(Violation("epistemic", entry_id, missing_msg + remediation))
             continue
 
         history_source_text = "\n".join(history_sources)

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -107,6 +107,22 @@ Graveyard files are append-only. Never edit existing graveyard entries.
   - Append-only history log (append only): `{{ epistemic_history_dir }}/E{NNN}.md`
 - Keep `{{ doc_paths.epistemic }}` concise. Put detailed, coherent per-claim state in the current file.
 
+## Epistemic Per-ID File Requirement (Required)
+
+If you create any new epistemic entry `E{NNN}` in this chunk:
+1. Create/update `{{ epistemic_current_dir }}/E{NNN}.md` with the matching `## E{NNN}: ...` heading.
+2. Create/update `{{ epistemic_history_dir }}/E{NNN}.md` with the matching heading and at least one support bullet (prefer `Evidence@<commit> ...`).
+3. Keep support content in either inline `Evidence:`/`History:` or inferred per-ID files (lint enforces this).
+
+{% set preassigned_e = pre_assigned_ids.get("E", []) %}
+{% if preassigned_e %}
+Pre-assigned epistemic IDs for this chunk (prepare files if used):
+{% for eid in preassigned_e %}
+- `{{ epistemic_current_dir }}/{{ eid }}.md`
+- `{{ epistemic_history_dir }}/{{ eid }}.md`
+{% endfor %}
+{% endif %}
+
 ## Important
 
 - Use Edit for surgical updates. Do NOT reproduce entire documents.

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1069,6 +1069,7 @@ class TestNextChunk:
         input_text = result.input_path.read_text()
         assert "# Instructions" in input_text
         assert "Pre-assigned IDs for this chunk" in input_text
+        assert "Epistemic Per-ID File Requirement (Required)" in input_text
         assert "For normal fold chunks, use ONLY this input file + the 4 living docs." in input_text
         assert "Do NOT inspect source code, git history, or filesystem state to verify claims." in input_text
         assert "[Pasted text #N +M lines]" in input_text
@@ -1158,6 +1159,9 @@ class TestNextChunk:
         assert result.pre_assigned_ids["C"] == ["C108"]
         assert result.pre_assigned_ids["E"] == ["E102"]
         assert result.pre_assigned_ids["W"] == ["W002"]
+        input_text = result.input_path.read_text()
+        assert "/epistemic_state/current/E102.md" in input_text
+        assert "/epistemic_state/history/E102.md" in input_text
 
     def test_fold_chunk_does_not_include_orphan_triage_section(self, project, config):
         registry = project / "docs" / "decisions" / "concept_registry.md"

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -339,6 +339,9 @@ Just a statement with no evidence chain.
         violations = validate_epistemic_state(doc, epistemic_path=epistemic_path)
         assert len(violations) == 1
         assert "inferred epistemic files not found" in violations[0].message
+        assert "Remediation:" in violations[0].message
+        assert "current=" in violations[0].message
+        assert "history=" in violations[0].message
 
     def test_inferred_history_file_must_match_entry_id(self, tmp_path: Path) -> None:
         doc = """\


### PR DESCRIPTION
## Summary
- add explicit fold-input guidance for new epistemic entries to create/update both inferred per-ID files (`current/E###.md` and `history/E###.md`)
- when pre-assigned epistemic IDs exist, render concrete file paths in `chunk_*_input.md` so agents can scaffold immediately
- improve epistemic lint violations to include direct remediation text with exact file paths and required support-content expectations
- add tests for prompt rendering and lint remediation messaging

## Validation
- `source venv/bin/activate && python -m pytest tests/test_chunker.py::TestNextChunk::test_normal_chunk tests/test_chunker.py::TestNextChunk::test_pre_assigned_ids_do_not_collide_with_existing_doc_ids tests/test_linter.py::TestEpistemicStateSchema::test_missing_inline_and_inferred_history_file_is_violation -v`
- `source venv/bin/activate && python -m pytest tests/test_chunker.py tests/test_linter.py -v`

Fixes #75
