### PR TITLE
Require detailed per-ID epistemic current files in fold prompts

### DIFF
--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -214,6 +214,7 @@ def render_agent_prompt(
         f"- Do NOT use the Task tool or spawn sub-agents. Do all work directly.\n"
         f"- Do NOT use Write to overwrite entire files. Use Edit for surgical updates only.\n"
         f"- Be SUCCINCT. High information density, no filler, no narrative prose.\n"
+        f"- Exception: per-ID epistemic current files ({epistemic_current_dir}/E*.md) should be detailed and coherent, not terse.\n"
         f"{repo_scope_constraints}"
         f"{epistemic_constraints}"
         f"\n"

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -98,7 +98,7 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - **Be succinct.** High information density. No filler.
 - Timeline: short factual entries. What happened, why, what resulted.
 - Concept registry: structured fields only. 5 lines ideal, 10 max.
-- Epistemic state: 1-2 sentence position. 1-sentence agent guidance.
+- Epistemic state (`epistemic_state.md`): 1-2 sentence position. 1-sentence agent guidance.
 - Workflow registry: structured fields only. Context + trigger/method.
 - DEAD/refuted entries: 1-2 sentences max. Key lesson + replacement.
 - **Budget matters.** Every line stays in context for future chunks. Be ruthless about cutting words.
@@ -106,6 +106,7 @@ Graveyard files are append-only. Never edit existing graveyard entries.
   - Mutable current state (rewrite when E{NNN} changes): `{{ epistemic_current_dir }}/E{NNN}.md`
   - Append-only history log (append only): `{{ epistemic_history_dir }}/E{NNN}.md`
 - Keep `{{ doc_paths.epistemic }}` concise. Put detailed, coherent per-claim state in the current file.
+- Per-ID current files (`{{ epistemic_current_dir }}/E{NNN}.md`) should be detailed and coherent (full claim state, rationale, caveats, and actionable guidance). Do NOT force brevity there.
 
 ## Epistemic Per-ID File Requirement (Required)
 
@@ -113,6 +114,7 @@ If you create any new epistemic entry `E{NNN}` in this chunk:
 1. Create/update `{{ epistemic_current_dir }}/E{NNN}.md` with the matching `## E{NNN}: ...` heading.
 2. Create/update `{{ epistemic_history_dir }}/E{NNN}.md` with the matching heading and at least one support bullet (prefer `Evidence@<commit> ...`).
 3. Keep support content in either inline `Evidence:`/`History:` or inferred per-ID files (lint enforces this).
+4. Write the current-state file as a detailed state description, not a terse stub.
 
 {% set preassigned_e = pre_assigned_ids.get("E", []) %}
 {% if preassigned_e %}

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1070,6 +1070,8 @@ class TestNextChunk:
         assert "# Instructions" in input_text
         assert "Pre-assigned IDs for this chunk" in input_text
         assert "Epistemic Per-ID File Requirement (Required)" in input_text
+        assert "Per-ID current files (" in input_text
+        assert "should be detailed and coherent" in input_text
         assert "For normal fold chunks, use ONLY this input file + the 4 living docs." in input_text
         assert "Do NOT inspect source code, git history, or filesystem state to verify claims." in input_text
         assert "[Pasted text #N +M lines]" in input_text
@@ -1083,6 +1085,7 @@ class TestNextChunk:
         assert "Do NOT inspect source code/git/filesystem for this chunk." in prompt_text
         assert "/epistemic_state/current/E*.md" in prompt_text
         assert "/epistemic_state/history/E*.md" in prompt_text
+        assert "should be detailed and coherent, not terse" in prompt_text
 
     def test_normal_chunk_creates_context_worktree_in_git_repo(self, project, config):
         subprocess.run(["git", "init"], cwd=project, check=True, capture_output=True)


### PR DESCRIPTION
## Summary
- clarify fold input style so `epistemic_state.md` stays concise but per-ID current files must be detailed
- add explicit requirement in epistemic per-ID section to write detailed current-state files (not terse stubs)
- add agent prompt constraint exception so the global succinctness rule does not compress `current/E*.md`
- update chunker test assertions for the new guidance

## Validation
- `source venv/bin/activate && python -m pytest tests/test_chunker.py::TestNextChunk::test_normal_chunk tests/test_chunker.py::TestNextChunk::test_pre_assigned_ids_do_not_collide_with_existing_doc_ids -v`
