### PR TITLE
Fix fold friction: contested requeue + workflow churn gates

### DIFF
--- a/engram/cli.py
+++ b/engram/cli.py
@@ -84,6 +84,7 @@ thresholds:
   stale_unverified_days: 30
   stale_epistemic_days: 90
   workflow_repetition: 3
+  workflow_new_id_synthesis_cooldown_chunks: 3
 
 budget:
   context_limit_chars: 600000

--- a/engram/config.py
+++ b/engram/config.py
@@ -39,6 +39,7 @@ DEFAULTS: dict[str, Any] = {
         "stale_unverified_days": 30,
         "stale_epistemic_days": 90,
         "workflow_repetition": 3,
+        "workflow_new_id_synthesis_cooldown_chunks": 3,
         # Reserve a small pool of IDs for normal fold chunks so background
         # agents can add genuinely new entries without inventing IDs even when
         # heuristics underestimate new entities.

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -79,7 +79,7 @@ _QUEUE_TEXT_CACHE: OrderedDict[tuple[str, str, int, int], str] = OrderedDict()
 # Evidence bullets in external epistemic history files.
 _EVIDENCE_COMMIT_RE = re.compile(r"Evidence@([0-9a-fA-F]{7,40})")
 _EVIDENCE_COMMIT_DATE_CACHE: dict[tuple[str, str], datetime | None] = {}
-_HEADING_LINE_COMMIT_DATE_CACHE: dict[tuple[str, str, int], datetime | None] = {}
+_HEADING_LINE_COMMIT_DATE_CACHE: dict[tuple[str, str, int, int, int], datetime | None] = {}
 _CHUNK_WORKTREE_NAME_RE = re.compile(r"^engram-chunk-\d{3,}-[0-9a-f]{8}-[A-Za-z0-9._-]+$")
 _WORKFLOW_EXPLICIT_SIGNAL_TERMS = (
     "new workflow",
@@ -609,7 +609,15 @@ def _resolve_git_line_commit_date(
     except ValueError:
         relative_path = str(file_path)
 
-    cache_key = (root_key, relative_path, line_number_1based)
+    try:
+        file_stat = file_path.stat()
+        file_mtime_ns = int(file_stat.st_mtime_ns)
+        file_size = int(file_stat.st_size)
+    except OSError:
+        file_mtime_ns = -1
+        file_size = -1
+
+    cache_key = (root_key, relative_path, line_number_1based, file_mtime_ns, file_size)
     if cache_key in _HEADING_LINE_COMMIT_DATE_CACHE:
         return _HEADING_LINE_COMMIT_DATE_CACHE[cache_key]
 

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -79,7 +79,7 @@ _QUEUE_TEXT_CACHE: OrderedDict[tuple[str, str, int, int], str] = OrderedDict()
 # Evidence bullets in external epistemic history files.
 _EVIDENCE_COMMIT_RE = re.compile(r"Evidence@([0-9a-fA-F]{7,40})")
 _EVIDENCE_COMMIT_DATE_CACHE: dict[tuple[str, str], datetime | None] = {}
-_HEADING_LINE_COMMIT_DATE_CACHE: dict[tuple[str, str, int, int, int], datetime | None] = {}
+_HEADING_LINE_COMMIT_DATE_CACHE: dict[tuple[str, str, int, int, int, str], datetime | None] = {}
 _CHUNK_WORKTREE_NAME_RE = re.compile(r"^engram-chunk-\d{3,}-[0-9a-f]{8}-[A-Za-z0-9._-]+$")
 _WORKFLOW_EXPLICIT_SIGNAL_TERMS = (
     "new workflow",
@@ -617,7 +617,15 @@ def _resolve_git_line_commit_date(
         file_mtime_ns = -1
         file_size = -1
 
-    cache_key = (root_key, relative_path, line_number_1based, file_mtime_ns, file_size)
+    head_commit = _resolve_head_commit(project_root) or "__no_head__"
+    cache_key = (
+        root_key,
+        relative_path,
+        line_number_1based,
+        file_mtime_ns,
+        file_size,
+        head_commit,
+    )
     if cache_key in _HEADING_LINE_COMMIT_DATE_CACHE:
         return _HEADING_LINE_COMMIT_DATE_CACHE[cache_key]
 

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -61,6 +61,7 @@ def render_chunk_input(
     date_range: str,
     items_content: str,
     pre_assigned_ids: dict[str, list[str]],
+    workflow_variant_only_mode: bool = False,
     doc_paths: dict[str, Path],
     context_worktree_path: Path | None = None,
     context_commit: str | None = None,
@@ -81,6 +82,7 @@ def render_chunk_input(
         doc_paths=_stringify_paths(doc_paths),
         **layout_vars,
         pre_assigned_ids=pre_assigned_ids,
+        workflow_variant_only_mode=workflow_variant_only_mode,
         context_worktree_path=str(context_worktree_path) if context_worktree_path else None,
         context_commit=context_commit,
     )
@@ -158,6 +160,7 @@ def render_agent_prompt(
     doc_paths: dict[str, Path],
     project_root: Path | None = None,
     pre_assigned_ids: dict[str, list[str]] | None = None,
+    workflow_variant_only_mode: bool = False,
     context_worktree_path: Path | None = None,
     context_commit: str | None = None,
 ) -> str:
@@ -268,13 +271,19 @@ def render_agent_prompt(
         f"- DEAD/refuted entries: 1-2 sentences max. Key lesson + what replaced it.\n"
         f"- Process ALL items in the chunk\n"
         f"- Use ONLY IDs listed under 'Pre-assigned IDs for this chunk'. If none are listed, do NOT create new IDs in this chunk.\n"
-        f"\n"
-        f"After All Edits: Lint Check (Required)\n"
-        f"\n"
-        f"Run the linter after completing all edits:\n"
-        f"  {lint_cmd}\n"
-        f"Fix every violation reported. Re-run until lint passes with 0 violations.\n"
-        f"Do not stop until lint is clean.\n"
+        + (
+            "- Workflow novelty gate: when no W IDs are pre-assigned for this chunk, "
+            "prefer updating an existing CURRENT workflow (usually W001 variant) instead of creating a new workflow entry.\n"
+            if workflow_variant_only_mode
+            else ""
+        )
+        + f"\n"
+        + f"After All Edits: Lint Check (Required)\n"
+        + f"\n"
+        + f"Run the linter after completing all edits:\n"
+        + f"  {lint_cmd}\n"
+        + f"Fix every violation reported. Re-run until lint passes with 0 violations.\n"
+        + f"Do not stop until lint is clean.\n"
     )
 
 

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -18,6 +18,9 @@ IDs survive renames, refactoring, and evolution. Never reuse an ID.
 
 Use ONLY these IDs for new entries. Do NOT invent your own.
 If no IDs are listed, do NOT create new entries/IDs in this chunk.
+{% if workflow_variant_only_mode %}
+No workflow IDs were pre-assigned by novelty gate. Prefer updating/adding variants on existing CURRENT workflows (usually W001) instead of creating a new W entry.
+{% endif %}
 
 {% if pre_assigned_ids %}
 {% for cat, ids in pre_assigned_ids.items() %}

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -397,6 +397,51 @@ class TestFindClaimsByStatus:
         assert len(results) == 1
         assert results[0]["id"] == "E021"
 
+    def test_recent_heading_commit_suppresses_old_contested_requeue(self, project):
+        subprocess.run(["git", "init"], cwd=project, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=project, check=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=project, check=True)
+
+        epistemic = project / "docs" / "decisions" / "epistemic_state.md"
+        old_date = (datetime.now(timezone.utc) - timedelta(days=60)).strftime("%Y-%m-%d")
+
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E001: callback parity baseline (believed)\n"
+            "**History:**\n"
+            f"- {old_date}: legacy investigation\n",
+        )
+        subprocess.run(["git", "add", "."], cwd=project, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial believed state"],
+            cwd=project,
+            check=True,
+            capture_output=True,
+        )
+
+        # Flip status now, but keep old dated history text.
+        epistemic.write_text(
+            "# Epistemic State\n\n"
+            "## E001: callback parity baseline (contested)\n"
+            "**History:**\n"
+            f"- {old_date}: legacy investigation\n",
+        )
+        subprocess.run(["git", "add", "."], cwd=project, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "flip claim to contested"],
+            cwd=project,
+            check=True,
+            capture_output=True,
+        )
+
+        results = _find_claims_by_status(
+            epistemic,
+            "contested",
+            14,
+            project_root=project,
+        )
+        assert results == []
+
 
 class TestFindStaleEpistemicEntries:
     def test_queue_text_cache_avoids_reread(self, project, monkeypatch):
@@ -1168,6 +1213,58 @@ class TestNextChunk:
         assert "/epistemic_state/current/E102.md" in input_text
         assert "/epistemic_state/history/E102.md" in input_text
 
+    def test_workflow_preassign_novelty_gate_prefers_existing_variant(self, project, config):
+        (project / "docs" / "decisions" / "workflow_registry.md").write_text(
+            "# Workflow Registry\n\n"
+            "## W001: dev_branch_workflow (CURRENT)\n- **Context:** baseline.\n\n"
+            "## W005: epistemic_audit_evidence_gate (CURRENT)\n- **Context:** audit.\n\n"
+            "## W013: subsystem_deletion_epic (CURRENT)\n- **Context:** deletion.\n",
+        )
+
+        doc_path = project / "docs" / "working" / "spec.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("# Test Spec\nGeneral updates\n")
+        _write_queue(project, [_make_doc_item(path="docs/working/spec.md", chars=100)])
+
+        result = next_chunk(config, project)
+        assert result.chunk_type == "fold"
+        assert "W" not in result.pre_assigned_ids
+        input_text = result.input_path.read_text()
+        assert "No workflow IDs were pre-assigned by novelty gate." in input_text
+
+    def test_workflow_synthesis_cooldown_after_recent_new_workflow(self, project, config):
+        workflows = project / "docs" / "decisions" / "workflow_registry.md"
+        workflows.write_text(
+            "# Workflow Registry\n\n"
+            "## W001: deploy_process (CURRENT)\n- **Context:** Deploy.\n\n"
+            "## W005: audit_process (CURRENT)\n- **Context:** Audit.\n\n"
+            "## W013: deletion_process (CURRENT)\n- **Context:** Delete.\n\n"
+            "## W025: windowed_loop (CURRENT)\n- **Context:** Windowed loop.\n\n",
+        )
+
+        # Simulate immediately previous fold pre-assigning W025.
+        chunks_dir = project / ".engram" / "chunks"
+        chunks_dir.mkdir(parents=True, exist_ok=True)
+        (chunks_dir / "chunk_001_input.md").write_text("# prior\n")
+        manifest = project / ".engram" / "chunks_manifest.yaml"
+        manifest.write_text(
+            "- id: 1\n"
+            "  date_range: \"2026-01-14 to 2026-01-14\"\n"
+            "  items: 1\n"
+            "  chars: 100\n"
+            "  input_file: chunk_001_input.md\n"
+            "  pre_assigned_workflow_ids:\n"
+            "    - W025\n",
+        )
+
+        doc_path = project / "docs" / "working" / "spec.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("Content")
+        _write_queue(project, [_make_doc_item(path="docs/working/spec.md", chars=100)])
+
+        result = next_chunk(config, project)
+        assert result.chunk_type == "fold"
+
     def test_fold_chunk_does_not_include_orphan_triage_section(self, project, config):
         registry = project / "docs" / "decisions" / "concept_registry.md"
         registry.write_text(
@@ -1485,3 +1582,20 @@ class TestNextChunk:
         input_text = result.input_path.read_text()
         for cid in result.pre_assigned_ids["C"]:
             assert cid in input_text
+
+    def test_manifest_records_pre_assigned_workflow_ids(self, project, config):
+        doc_path = project / "docs" / "working" / "workflow_spec.md"
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        doc_path.write_text("workflow changes")
+
+        item = _make_doc_item(path="docs/working/workflow_spec.md", chars=100)
+        item["entity_hints"] = [{"category": "W"}]
+        _write_queue(project, [item])
+
+        result = next_chunk(config, project)
+        assert result.chunk_type == "fold"
+        assert result.pre_assigned_ids["W"] == ["W001"]
+
+        manifest_text = (project / ".engram" / "chunks_manifest.yaml").read_text()
+        assert "pre_assigned_workflow_ids" in manifest_text
+        assert "- W001" in manifest_text


### PR DESCRIPTION
## Summary
- Fix contested-review requeue behavior by considering per-claim heading commit recency (line-level git blame) when computing contested age.
- Add workflow churn controls:
  - suppress immediate `workflow_synthesis` when a newly pre-assigned workflow ID was introduced in recent chunks and workflow count only increased minimally.
  - apply a workflow novelty gate for fold chunks: when `W001` already covers the default workflow surface and there is no explicit workflow signal in chunk items, skip floor-based W pre-assignment and instruct agent to update existing workflow variants.
- Persist `pre_assigned_workflow_ids` in fold manifest entries to support cooldown logic.
- Add prompt/template guidance for novelty-gated chunks.
- Add regression tests for contested requeue guard and workflow churn controls.

## Testing
- `python -m pytest tests/test_chunker.py tests/test_ids.py tests/test_config.py -q`
- `python -m pytest tests -q`

Fixes #79
