### PR TITLE
Require timeline phase IDs in fold output

### DIFF
--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -267,6 +267,8 @@ def render_agent_prompt(
         f"\n"
         f"Rules:\n"
         f"- Extract concepts, claims, timeline events, workflows from the chunk\n"
+        f"- Every timeline phase entry must include 'IDs:' with C###/E###/W### "
+        f"or 'IDs: NONE(reason)' when no stable ID applies.\n"
         f"- USER PROMPTS encode the project owner's intent — they are authoritative\n"
         f"- DEAD/refuted entries: 1-2 sentences max. Key lesson + what replaced it.\n"
         f"- Process ALL items in the chunk\n"

--- a/engram/linter/__init__.py
+++ b/engram/linter/__init__.py
@@ -20,6 +20,7 @@ from engram.linter.schema import (
     Violation,
     validate_concept_registry,
     validate_epistemic_state,
+    validate_timeline,
     validate_workflow_registry,
 )
 
@@ -70,6 +71,8 @@ def lint(
         violations.extend(validate_epistemic_state(living_docs["epistemic"], epistemic_path))
     if "workflows" in living_docs:
         violations.extend(validate_workflow_registry(living_docs["workflows"]))
+    if "timeline" in living_docs:
+        violations.extend(validate_timeline(living_docs["timeline"]))
 
     # Cross-reference validation (needs all docs combined)
     all_contents: dict[str, str] = dict(living_docs)

--- a/engram/linter/schema.py
+++ b/engram/linter/schema.py
@@ -28,7 +28,7 @@ from engram.epistemic_history import (
     infer_current_path,
     infer_history_path,
 )
-from engram.parse import Section, extract_id, is_stub, parse_sections
+from engram.parse import PHASE_RE, Section, extract_id, is_stub, parse_sections
 
 
 # -- Heading patterns per doc type -----------------------------------------
@@ -86,6 +86,12 @@ _EPISTEMIC_STATUS_RE = re.compile(
 _CONTEXT_RE = re.compile(r'^\s*-?\s*\*?\*?Context\*?\*?:', re.MULTILINE)
 _TRIGGER_RE = re.compile(r'^\s*-?\s*\*?\*?Trigger(?:\s+for\s+change)?\*?\*?:', re.MULTILINE)
 _CURRENT_METHOD_RE = re.compile(r'^\s*-?\s*\*?\*?Current method\*?\*?:', re.MULTILINE)
+_TIMELINE_IDS_RE = re.compile(
+    r'^\s*-?\s*(?:\*\*IDs:\*\*|IDs:)\s*(.+?)\s*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+_TIMELINE_NONE_RE = re.compile(r'^NONE\((.*)\)$', re.IGNORECASE)
+_TIMELINE_ID_TOKEN_RE = re.compile(r'^[CEW]\d{3,}$')
 
 
 def _has_external_support_content(section_text: str) -> bool:
@@ -434,6 +440,69 @@ def validate_workflow_registry(content: str) -> list[Violation]:
                 "workflows", entry_id,
                 "CURRENT workflow missing required "
                 "'Trigger:' or 'Current method:' field",
+            ))
+
+    return violations
+
+
+def validate_timeline(content: str) -> list[Violation]:
+    """Validate timeline phase ID-qualification rules."""
+    violations: list[Violation] = []
+    sections = parse_sections(content)
+
+    for section in sections:
+        heading = section["heading"]
+        if not PHASE_RE.match(heading):
+            continue
+
+        phase_label = heading.removeprefix("## ").strip()
+        match = _TIMELINE_IDS_RE.search(section["text"])
+        if not match:
+            violations.append(Violation(
+                "timeline",
+                None,
+                f"Timeline phase '{phase_label}' missing required 'IDs:' field. "
+                "Use 'IDs: C###, E###, W###' or 'IDs: NONE(reason)'.",
+            ))
+            continue
+
+        value = match.group(1).strip()
+        if not value:
+            violations.append(Violation(
+                "timeline",
+                None,
+                f"Timeline phase '{phase_label}' has empty 'IDs:' field.",
+            ))
+            continue
+
+        none_match = _TIMELINE_NONE_RE.fullmatch(value)
+        if none_match:
+            reason = none_match.group(1).strip()
+            if not reason:
+                violations.append(Violation(
+                    "timeline",
+                    None,
+                    f"Timeline phase '{phase_label}' uses 'IDs: NONE(...)' without a reason.",
+                ))
+            continue
+
+        tokens = [token.strip() for token in value.split(",") if token.strip()]
+        if not tokens:
+            violations.append(Violation(
+                "timeline",
+                None,
+                f"Timeline phase '{phase_label}' has malformed 'IDs:' list; "
+                "provide comma-separated stable IDs.",
+            ))
+            continue
+
+        invalid_tokens = [token for token in tokens if not _TIMELINE_ID_TOKEN_RE.fullmatch(token)]
+        if invalid_tokens:
+            violations.append(Violation(
+                "timeline",
+                None,
+                f"Timeline phase '{phase_label}' has invalid ID tokens: "
+                f"{', '.join(invalid_tokens)}. Use C###/E###/W### or NONE(reason).",
             ))
 
     return violations

--- a/engram/linter/schema.py
+++ b/engram/linter/schema.py
@@ -87,7 +87,7 @@ _CONTEXT_RE = re.compile(r'^\s*-?\s*\*?\*?Context\*?\*?:', re.MULTILINE)
 _TRIGGER_RE = re.compile(r'^\s*-?\s*\*?\*?Trigger(?:\s+for\s+change)?\*?\*?:', re.MULTILINE)
 _CURRENT_METHOD_RE = re.compile(r'^\s*-?\s*\*?\*?Current method\*?\*?:', re.MULTILINE)
 _TIMELINE_IDS_RE = re.compile(
-    r'^\s*-?\s*(?:\*\*IDs:\*\*|IDs:)\s*(.+?)\s*$',
+    r'^\s*-?\s*(?:\*\*IDs:\*\*|\*\*IDs\*\*:|IDs:)\s*(.+?)\s*$',
     re.IGNORECASE | re.MULTILINE,
 )
 _TIMELINE_NONE_RE = re.compile(r'^NONE\((.*)\)$', re.IGNORECASE)

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -100,6 +100,9 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 
 - **Be succinct.** High information density. No filler.
 - Timeline: short factual entries. What happened, why, what resulted.
+- Every timeline phase (`## Phase: ...`) must include an `IDs:` line:
+  - `IDs: C###, E###, W###` (one or more stable IDs), or
+  - `IDs: NONE(reason)` when no stable ID applies.
 - Concept registry: structured fields only. 5 lines ideal, 10 max.
 - Epistemic state (`epistemic_state.md`): 1-2 sentence position. 1-sentence agent guidance.
 - Workflow registry: structured fields only. Context + trigger/method.

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1306,6 +1306,7 @@ class TestNextChunk:
         input_text = result.input_path.read_text()
         assert "# Instructions" in input_text
         assert "Pre-assigned IDs for this chunk" in input_text
+        assert "Every timeline phase (`## Phase: ...`) must include an `IDs:` line" in input_text
         assert "Epistemic Per-ID File Requirement (Required)" in input_text
         assert "Per-ID current files (" in input_text
         assert "should be detailed and coherent" in input_text
@@ -1318,6 +1319,7 @@ class TestNextChunk:
         prompt_text = result.prompt_path.read_text()
         assert "knowledge fold chunk" in prompt_text
         assert "Pre-assigned IDs for this chunk" in prompt_text
+        assert "Every timeline phase entry must include 'IDs:'" in prompt_text
         assert "For standard fold/workflow_synthesis chunks, use only the input file + living docs." in prompt_text
         assert "Do NOT inspect source code/git/filesystem for this chunk." in prompt_text
         assert "/epistemic_state/current/E*.md" in prompt_text

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -17,6 +17,7 @@ from engram.linter.schema import (
     Violation,
     validate_concept_registry,
     validate_epistemic_state,
+    validate_timeline,
     validate_workflow_registry,
 )
 
@@ -74,10 +75,12 @@ VALID_TIMELINE = """\
 # Timeline
 
 ## Phase: Early Architecture (2024-Q4)
+IDs: C001, E001, W002
 
 Built initial swing detection with LegDetector (C001). Single-timeframe.
 
 ## Phase: Signal Rework (2025-Q1)
+IDs: C003
 
 Replaced proximity pruning (C003 DEAD) with structure-driven approach.
 """
@@ -546,6 +549,70 @@ Just a description, no required fields.
 """
         violations = validate_workflow_registry(doc)
         assert len(violations) == 2
+
+
+# ======================================================================
+# Schema: timeline
+# ======================================================================
+
+class TestTimelineSchema:
+    def test_valid_timeline_with_ids(self) -> None:
+        assert validate_timeline(VALID_TIMELINE) == []
+
+    def test_phase_missing_ids_field(self) -> None:
+        doc = """\
+# Timeline
+
+## Phase: Missing IDs (2026-Q1)
+Narrative event without qualification.
+"""
+        violations = validate_timeline(doc)
+        assert len(violations) == 1
+        assert "missing required 'IDs:' field" in violations[0].message
+
+    def test_phase_none_with_reason_is_valid(self) -> None:
+        doc = """\
+# Timeline
+
+## Phase: Project Setup (2024-Q1)
+IDs: NONE(pure onboarding logistics, no canonical entities yet)
+Created repository and basic tooling.
+"""
+        assert validate_timeline(doc) == []
+
+    def test_phase_none_without_reason_is_invalid(self) -> None:
+        doc = """\
+# Timeline
+
+## Phase: Empty None (2024-Q1)
+IDs: NONE()
+Created repository and basic tooling.
+"""
+        violations = validate_timeline(doc)
+        assert len(violations) == 1
+        assert "without a reason" in violations[0].message
+
+    def test_phase_invalid_id_token(self) -> None:
+        doc = """\
+# Timeline
+
+## Phase: Bad IDs (2025-Q2)
+IDs: C001, Z999
+Updated approach.
+"""
+        violations = validate_timeline(doc)
+        assert len(violations) == 1
+        assert "invalid ID tokens" in violations[0].message
+
+    def test_phase_bullet_bold_ids_format(self) -> None:
+        doc = """\
+# Timeline
+
+## Phase: Alternate IDs Formatting (2025-Q3)
+- **IDs:** C001, E002
+Updated approach.
+"""
+        assert validate_timeline(doc) == []
 
 
 # ======================================================================

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -614,6 +614,16 @@ Updated approach.
 """
         assert validate_timeline(doc) == []
 
+    def test_phase_bullet_bold_label_ids_format(self) -> None:
+        doc = """\
+# Timeline
+
+## Phase: Alternate IDs Label Formatting (2025-Q3)
+- **IDs**: C001, E002
+Updated approach.
+"""
+        assert validate_timeline(doc) == []
+
 
 # ======================================================================
 # Cross-reference validation


### PR DESCRIPTION
## Summary
- add timeline schema validation that requires an `IDs:` field for every `## Phase: ...` section
- allow either a comma-separated stable ID list (`C###`, `E###`, `W###`) or `IDs: NONE(reason)`
- wire timeline validation into the main lint flow
- update fold prompt guidance (chunk input and agent prompt) so fold agents consistently emit the new format
- add/adjust tests for timeline schema behavior and prompt rendering

## Validation
- `source venv/bin/activate && python -m pytest tests/test_linter.py tests/test_chunker.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

Fixes #83
