### PR TITLE
Refresh issue snapshots and git-source doc discovery for queue builds

### DIFF
--- a/engram/bootstrap/fold.py
+++ b/engram/bootstrap/fold.py
@@ -20,7 +20,7 @@ from typing import Any
 from engram.config import load_config, resolve_doc_paths
 from engram.dispatch import invoke_agent, read_docs
 from engram.fold.chunker import ChunkResult, cleanup_chunk_context_worktree, next_chunk
-from engram.fold.queue import build_queue
+from engram.fold.queue import build_queue, refresh_issue_snapshots
 from engram.linter import lint_post_dispatch
 from engram.server.briefing import regenerate_l0_briefing
 from engram.server.db import ServerDB
@@ -134,6 +134,12 @@ def forward_fold(
     """
     if config is None:
         config = load_config(project_root)
+
+    refreshed, refresh_message = refresh_issue_snapshots(config, project_root)
+    if not refreshed:
+        log.error("Issue refresh failed: %s", refresh_message)
+        return False
+    log.info("Issue refresh: %s", refresh_message)
 
     # Step 1: Build queue (filtered by from_date)
     log.info("Building queue...")

--- a/engram/bootstrap/fold.py
+++ b/engram/bootstrap/fold.py
@@ -84,6 +84,7 @@ def _dispatch_and_validate(
             expected_growth=chunk.chunk_chars,
             config=config,
             project_root=project_root,
+            chunk_type=chunk.chunk_type,
         )
 
         if result.passed:

--- a/engram/config.py
+++ b/engram/config.py
@@ -26,6 +26,8 @@ DEFAULTS: dict[str, Any] = {
     },
     "sources": {
         "issues": "local_data/issues/",
+        "refresh_issues": True,
+        "github_repo": None,
         "docs": ["docs/working/", "docs/archive/", "docs/specs/"],
         "sessions": {
             "format": "claude-code",

--- a/engram/fold/prompt.py
+++ b/engram/fold/prompt.py
@@ -269,6 +269,8 @@ def render_agent_prompt(
         f"- Extract concepts, claims, timeline events, workflows from the chunk\n"
         f"- Every timeline phase entry must include 'IDs:' with C###/E###/W### "
         f"or 'IDs: NONE(reason)' when no stable ID applies.\n"
+        f"- If concepts/epistemic/workflows are unchanged in this chunk, append a "
+        f"timeline phase that explicitly includes the phrase 'No canonical delta'.\n"
         f"- USER PROMPTS encode the project owner's intent — they are authoritative\n"
         f"- DEAD/refuted entries: 1-2 sentences max. Key lesson + what replaced it.\n"
         f"- Process ALL items in the chunk\n"

--- a/engram/fold/queue.py
+++ b/engram/fold/queue.py
@@ -56,6 +56,8 @@ def refresh_issue_snapshots(config: dict[str, Any], project_root: Path) -> tuple
         stderr = (exc.stderr or "").strip()
         detail = f": {stderr}" if stderr else ""
         return False, f"gh issue list failed for {repo}{detail}"
+    except FileNotFoundError:
+        return False, "gh CLI not found while refreshing issues"
 
     return True, f"refreshed {len(issues)} issues from {repo}"
 

--- a/engram/linter/__init__.py
+++ b/engram/linter/__init__.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from engram.linter.guards import (
+    check_fold_chunk_delta_documentation,
     check_diff_size,
     check_id_compliance,
     check_missing_sections,
@@ -93,6 +94,7 @@ def lint_post_dispatch(
     expected_growth: int = 0,
     config: dict[str, Any] | None = None,
     project_root: Path | None = None,
+    chunk_type: str | None = None,
 ) -> LintResult:
     """Full post-dispatch validation: schema + refs + guards.
 
@@ -130,6 +132,8 @@ def lint_post_dispatch(
         violations.extend(check_diff_size(before_total, after_total, expected_growth))
 
     violations.extend(check_missing_sections(before_contents, after_contents))
+    if chunk_type == "fold":
+        violations.extend(check_fold_chunk_delta_documentation(before_contents, after_contents))
 
     if pre_assigned_ids:
         violations.extend(check_id_compliance(

--- a/engram/server/dispatcher.py
+++ b/engram/server/dispatcher.py
@@ -155,6 +155,7 @@ class Dispatcher:
                 expected_growth=chunk.chunk_chars,
                 config=self._config,
                 project_root=self._project_root,
+                chunk_type=chunk.chunk_type,
             )
 
             if result.passed:

--- a/engram/templates/fold_prompt.md
+++ b/engram/templates/fold_prompt.md
@@ -116,6 +116,8 @@ Graveyard files are append-only. Never edit existing graveyard entries.
 - Every timeline phase (`## Phase: ...`) must include an `IDs:` line:
   - `IDs: C###, E###, W###` (one or more stable IDs), or
   - `IDs: NONE(reason)` when no stable ID applies.
+- If this chunk yields no concept/epistemic/workflow changes, append a timeline phase
+  that explicitly contains the phrase `No canonical delta` and explains why.
 - Concept registry: structured fields only. 5 lines ideal, 10 max.
 - Epistemic state (`epistemic_state.md`): 1-2 sentence position. 1-sentence agent guidance.
 - Workflow registry: structured fields only. Context + trigger/method.

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1352,6 +1352,7 @@ class TestNextChunk:
         assert "# Instructions" in input_text
         assert "Pre-assigned IDs for this chunk" in input_text
         assert "Every timeline phase (`## Phase: ...`) must include an `IDs:` line" in input_text
+        assert "No canonical delta" in input_text
         assert "Epistemic Per-ID File Requirement (Required)" in input_text
         assert "Per-ID current files (" in input_text
         assert "should be detailed and coherent" in input_text
@@ -1365,6 +1366,7 @@ class TestNextChunk:
         assert "knowledge fold chunk" in prompt_text
         assert "Pre-assigned IDs for this chunk" in prompt_text
         assert "Every timeline phase entry must include 'IDs:'" in prompt_text
+        assert "No canonical delta" in prompt_text
         assert "For standard fold/workflow_synthesis chunks, use only the input file + living docs." in prompt_text
         assert "Do NOT inspect source code/git/filesystem for this chunk." in prompt_text
         assert "/epistemic_state/current/E*.md" in prompt_text

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -545,6 +545,15 @@ class TestIssueRefresh:
         assert ok is False
         assert "gh issue list failed for owner/repo" in message
 
+    def test_refresh_returns_failure_when_gh_missing(self, project: Path) -> None:
+        config = _make_config(project, {"sources": {"github_repo": "owner/repo"}})
+
+        with patch("engram.fold.queue.pull_issues", side_effect=FileNotFoundError("gh")):
+            ok, message = refresh_issue_snapshots(config, project)
+
+        assert ok is False
+        assert "gh CLI not found" in message
+
 
 class TestGitTrackedDocDiscovery:
     def test_prefers_git_tracked_docs_when_available(self, project: Path) -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -12,7 +13,7 @@ import pytest
 import yaml
 
 from engram.config import DEFAULTS, _deep_merge
-from engram.fold.queue import REVISIT_THRESHOLD_DAYS, build_queue
+from engram.fold.queue import REVISIT_THRESHOLD_DAYS, build_queue, refresh_issue_snapshots
 
 
 @pytest.fixture
@@ -507,3 +508,58 @@ class TestBuildQueueStartDate:
         # Only surviving session file should exist
         assert (sessions_dir / "new-session.md").exists()
         assert not (sessions_dir / "old-session.md").exists()
+
+
+class TestIssueRefresh:
+    def test_refresh_uses_explicit_repo(self, project: Path) -> None:
+        config = _make_config(project, {"sources": {"github_repo": "owner/repo"}})
+
+        with patch("engram.fold.queue.pull_issues", return_value=[{"number": 1}]) as mock_pull:
+            ok, message = refresh_issue_snapshots(config, project)
+
+        assert ok is True
+        assert "refreshed 1 issues from owner/repo" in message
+        mock_pull.assert_called_once_with("owner/repo", project / "issues")
+
+    def test_refresh_skips_when_repo_unresolved(self, project: Path) -> None:
+        config = _make_config(project, {"sources": {"github_repo": None}})
+
+        with patch("engram.fold.queue.infer_github_repo", return_value=None):
+            ok, message = refresh_issue_snapshots(config, project)
+
+        assert ok is True
+        assert "using local issue snapshots" in message
+
+    def test_refresh_returns_failure_when_gh_fails(self, project: Path) -> None:
+        config = _make_config(project, {"sources": {"github_repo": "owner/repo"}})
+
+        called_process_error = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["gh", "issue", "list"],
+            stderr="authentication failed",
+        )
+
+        with patch("engram.fold.queue.pull_issues", side_effect=called_process_error):
+            ok, message = refresh_issue_snapshots(config, project)
+
+        assert ok is False
+        assert "gh issue list failed for owner/repo" in message
+
+
+class TestGitTrackedDocDiscovery:
+    def test_prefers_git_tracked_docs_when_available(self, project: Path) -> None:
+        tracked = project / "docs" / "working" / "tracked.md"
+        untracked = project / "docs" / "working" / "scratch.md"
+        tracked.write_text("**Date:** 2026-01-01\n\nTracked")
+        untracked.write_text("**Date:** 2026-01-01\n\nUntracked")
+
+        config = _make_config(project)
+
+        with (
+            patch("engram.fold.queue.list_tracked_markdown_docs", return_value=[tracked]),
+            patch("engram.fold.sources.subprocess.run", side_effect=_mock_git_run),
+        ):
+            entries = build_queue(config, project)
+
+        doc_paths = [e["path"] for e in entries if e["type"] == "doc"]
+        assert doc_paths == ["docs/working/tracked.md"]


### PR DESCRIPTION
## Summary
- refresh issue snapshots from GitHub before `build-queue` runs, with explicit failure in CLI when refresh fails (unless `--no-refresh-issues`)
- run the same issue-refresh step in forward fold (`engram fold`) so queue generation does not silently run on stale issue JSON
- source doc artifacts from git-tracked markdown files when available (`git ls-files`), with filesystem fallback when git metadata is unavailable
- add config/template keys for issue refresh control and explicit repo override (`sources.refresh_issues`, `sources.github_repo`)
- harden refresh error handling for environments without `gh` installed (returns deterministic failure message instead of uncaught exception)
- enforce documented no-op fold behavior for normal chunks:
  - prompt/template now requires explicit `No canonical delta` timeline phase when C/E/W stay unchanged
  - linter guard rejects fold chunks with zero living-doc changes
  - linter guard rejects timeline-only fold updates that do not newly add `No canonical delta`
- add regression tests for refresh behavior (including missing `gh`), prompt guidance, and fold no-op guard behavior

## Why
Queue generation had a stale-data gap: issues/comments depended on local snapshots that were never refreshed. This caused chunks to miss newer issue/comment artifacts.

We also need fold outputs to be auditable: if a chunk produces no C/E/W deltas, the timeline must explicitly document that no canonical update occurred.

## Validation
- `source venv/bin/activate && python -m pytest tests/test_queue.py tests/test_chunker.py tests/test_linter.py tests/test_cli.py tests/test_bootstrap.py tests/test_temporal_orphan_triage.py -q`

Fixes #88
