### PR TITLE
Enforce lookup hooks in autogenerated L0 briefings

### DIFF
--- a/engram/server/briefing.py
+++ b/engram/server/briefing.py
@@ -48,7 +48,7 @@ def regenerate_l0_briefing(
     if not living_contents:
         return False
 
-    lookup_patterns = _build_lookup_patterns(doc_paths)
+    lookup_patterns = _build_lookup_patterns(doc_paths, project_root)
 
     # Generate briefing via lightweight model call
     briefing_text = _generate_briefing(
@@ -111,17 +111,25 @@ def _generate_briefing(
     return None
 
 
-def _build_lookup_patterns(doc_paths: dict[str, Path]) -> dict[str, str]:
+def _build_lookup_patterns(doc_paths: dict[str, Path], project_root: Path) -> dict[str, str]:
     """Build per-ID file lookup patterns for L0 briefing instructions."""
-    concepts = doc_paths["concepts"].with_suffix("")
-    epistemic = doc_paths["epistemic"].with_suffix("")
-    workflows = doc_paths["workflows"].with_suffix("")
+    concepts = _to_repo_relative(doc_paths["concepts"], project_root).with_suffix("")
+    epistemic = _to_repo_relative(doc_paths["epistemic"], project_root).with_suffix("")
+    workflows = _to_repo_relative(doc_paths["workflows"], project_root).with_suffix("")
     return {
         "concepts": f"{concepts}/current/C###.md",
         "epistemic_current": f"{epistemic}/current/E###.md",
         "epistemic_history": f"{epistemic}/history/E###.md",
         "workflows": f"{workflows}/current/W###.md",
     }
+
+
+def _to_repo_relative(path: Path, project_root: Path) -> Path:
+    """Return path relative to project root when possible."""
+    try:
+        return path.resolve().relative_to(project_root.resolve())
+    except ValueError:
+        return path
 
 
 def _inject_section(file_path: Path, section_header: str, content: str) -> None:

--- a/tests/test_l0_drain.py
+++ b/tests/test_l0_drain.py
@@ -486,11 +486,11 @@ class TestRegenerateL0Briefing:
         from engram.server.briefing import _build_lookup_patterns
 
         doc_paths = resolve_doc_paths(config, project)
-        patterns = _build_lookup_patterns(doc_paths)
-        assert patterns["concepts"].endswith("docs/decisions/concept_registry/current/C###.md")
-        assert patterns["epistemic_current"].endswith("docs/decisions/epistemic_state/current/E###.md")
-        assert patterns["epistemic_history"].endswith("docs/decisions/epistemic_state/history/E###.md")
-        assert patterns["workflows"].endswith("docs/decisions/workflow_registry/current/W###.md")
+        patterns = _build_lookup_patterns(doc_paths, project)
+        assert patterns["concepts"] == "docs/decisions/concept_registry/current/C###.md"
+        assert patterns["epistemic_current"] == "docs/decisions/epistemic_state/current/E###.md"
+        assert patterns["epistemic_history"] == "docs/decisions/epistemic_state/history/E###.md"
+        assert patterns["workflows"] == "docs/decisions/workflow_registry/current/W###.md"
 
     @patch("engram.server.briefing.subprocess.run")
     def test_generate_briefing_prompt_includes_lookup_hooks(self, mock_run: MagicMock, project: Path, config: dict) -> None:

--- a/tests/test_l0_drain.py
+++ b/tests/test_l0_drain.py
@@ -492,6 +492,25 @@ class TestRegenerateL0Briefing:
         assert patterns["epistemic_history"] == "docs/decisions/epistemic_state/history/E###.md"
         assert patterns["workflows"] == "docs/decisions/workflow_registry/current/W###.md"
 
+    def test_lookup_patterns_stay_relative_for_external_doc_paths(self, project: Path) -> None:
+        from engram.server.briefing import _build_lookup_patterns
+
+        external_root = project.parent / "external_docs"
+        external_root.mkdir(exist_ok=True)
+        external_concepts = external_root / "concept_registry.md"
+        external_concepts.write_text("# Concept Registry\n")
+
+        doc_paths = {
+            "concepts": external_concepts,
+            "epistemic": project / "docs" / "decisions" / "epistemic_state.md",
+            "workflows": project / "docs" / "decisions" / "workflow_registry.md",
+            "timeline": project / "docs" / "decisions" / "timeline.md",
+        }
+
+        patterns = _build_lookup_patterns(doc_paths, project)
+        assert not Path(patterns["concepts"]).is_absolute()
+        assert patterns["concepts"].startswith("../")
+
     @patch("engram.server.briefing.subprocess.run")
     def test_generate_briefing_prompt_includes_lookup_hooks(self, mock_run: MagicMock, project: Path, config: dict) -> None:
         from engram.server.briefing import _generate_briefing


### PR DESCRIPTION
## Summary
- update L0 briefing generation prompt to require self-contained ID lines (inline gloss on first mention)
- require a dedicated `Lookup Hooks (Use When Needed)` section in generated briefings
- inject explicit per-ID lookup patterns (concept current, epistemic current/history, workflow current) into the prompt
- add tests for lookup pattern derivation and prompt content requirements

## Why
Generated L0 summaries were using IDs without enough hooks, so lower-context agents had no deterministic path into richer per-ID state. This change makes lookup escalation explicit and repeatable.

## Validation
- `source venv/bin/activate && python -m pytest tests/test_l0_drain.py -v`
