### PR TITLE
Fix L0 briefing: executive prompt, no truncation, configurable (#91)

### DIFF
--- a/engram/server/briefing.py
+++ b/engram/server/briefing.py
@@ -130,11 +130,14 @@ def _generate_briefing(
     else:
         cmd = ["claude", "--print", "--model", model]
 
-    cmd.append(prompt)
+    # Pass prompt via stdin to avoid OS argv size limits (E2BIG)
+    # on large living docs.  claude --print reads stdin when given "-".
+    cmd.append("-")
 
     try:
         result = subprocess.run(
             cmd,
+            input=prompt,
             capture_output=True,
             text=True,
             cwd=str(project_root),
@@ -152,6 +155,8 @@ def _generate_briefing(
         log.warning("L0 briefing generation timed out (300s)")
     except FileNotFoundError:
         log.warning("Agent command not found: %s", cmd[0])
+    except OSError as exc:
+        log.warning("L0 briefing OS error: %s", exc)
 
     return None
 

--- a/engram/server/briefing.py
+++ b/engram/server/briefing.py
@@ -14,6 +14,39 @@ from typing import Any
 
 log = logging.getLogger(__name__)
 
+DEFAULT_PROMPT = """\
+Write an executive briefing for an engineer who just woke up with zero context \
+about this project. Every token matters — every agent in the system reads this \
+file on every session start.
+
+Guiding question: What does an agent need to know to operate in this codebase \
+without breaking things?
+
+INCLUDE:
+- What is this project? (2-3 sentences max)
+- Current runtime architecture in plain English with key file paths
+- What works, what's broken, what's the active research direction
+- Hard rules (things an agent must never do)
+- Key file paths table
+- How to debug issues
+
+DO NOT INCLUDE:
+- Dead concepts — if something is deleted, don't mention it. Exception: if an \
+agent might search for a file that used to exist, one line saying it doesn't exist.
+- Engram concept IDs (C###), epistemic IDs (E###), or workflow IDs (W###) — \
+these are internal bookkeeping, not operator-useful.
+- Workflow registry dumps — state rules plainly.
+- Lookup hooks to engram per-ID files.
+
+Tone: executive briefing. Dense. Every line earns its place. If a line doesn't \
+help an agent make a decision or avoid a mistake, cut it.
+
+Target: 60-80 lines.
+
+Project knowledge follows:
+
+"""
+
 
 def regenerate_l0_briefing(
     config: dict[str, Any],
@@ -22,8 +55,8 @@ def regenerate_l0_briefing(
 ) -> bool:
     """Regenerate the L0 briefing section in the project's CLAUDE.md.
 
-    Uses a lightweight model call to compress living docs into a
-    concise briefing (~50-100 lines).
+    Uses a model call to compress living docs into a concise executive
+    briefing (~60-80 lines).
 
     Returns True on success, False on failure.
     """
@@ -35,94 +68,92 @@ def regenerate_l0_briefing(
         log.warning("Briefing target file not found: %s", target_file)
         return False
 
-    # Read current living docs for briefing generation
-    living_contents: list[str] = []
-    for key in ("timeline", "concepts", "epistemic", "workflows"):
-        p = doc_paths.get(key)
-        if p and p.exists():
-            content = p.read_text()
-            # Truncate very large docs for briefing generation
-            if len(content) > 10_000:
-                content = content[:10_000] + "\n\n[... truncated for briefing ...]\n"
-            living_contents.append(f"### {key.title()}\n{content}")
-
+    living_contents = _read_living_docs(doc_paths)
     if not living_contents:
         return False
 
-    lookup_patterns = _build_lookup_patterns(doc_paths, project_root)
-
-    # Generate briefing via lightweight model call
     briefing_text = _generate_briefing(
         config,
         project_root,
         "\n\n".join(living_contents),
-        lookup_patterns,
     )
     if not briefing_text:
         log.warning("L0 briefing generation returned empty result")
         return False
 
-    # Inject into target file
     _inject_section(target_file, section_header, briefing_text)
     log.info("L0 briefing regenerated in %s", target_file)
     return True
+
+
+def _read_living_docs(doc_paths: dict[str, Path]) -> list[str]:
+    """Read living docs for briefing generation.
+
+    Skips timeline (too large, mostly historical narrative).
+    Reads concepts, epistemic, and workflows in full — these are the
+    docs that contain actionable current-state information.
+    """
+    contents: list[str] = []
+    for key in ("concepts", "epistemic", "workflows"):
+        p = doc_paths.get(key)
+        if p and p.exists():
+            content = p.read_text()
+            contents.append(f"### {key.title()}\n{content}")
+    return contents
 
 
 def _generate_briefing(
     config: dict[str, Any],
     project_root: Path,
     living_docs_content: str,
-    lookup_patterns: dict[str, str],
 ) -> str | None:
-    """Generate L0 briefing by shelling out to a fast model.
+    """Generate L0 briefing by shelling out to the configured model.
+
+    Uses ``briefing.prompt`` from config if set, otherwise falls back
+    to the built-in executive briefing prompt.  Uses the project's
+    ``agent_command`` or ``model`` for the model call.
 
     Returns the briefing text, or None on failure.
     """
-    prompt = (
-        "Compress the following project knowledge into a concise briefing "
-        "(50-100 lines). Focus on: what's alive vs dead, contested claims, "
-        "key workflows, and agent guidance. Use stable IDs (C###/E###/W###).\n\n"
-        "Output requirements:\n"
-        "1) Keep the briefing self-contained: when an ID is first introduced, add a "
-        "short inline gloss so the line is understandable without opening other files.\n"
-        "2) Include a section titled 'Lookup Hooks (Use When Needed)' that tells agents "
-        "exactly which per-ID files to open for deeper context.\n"
-        "3) In Lookup Hooks, include these file patterns exactly:\n"
-        f"- Concept details: {lookup_patterns['concepts']}\n"
-        f"- Epistemic current state: {lookup_patterns['epistemic_current']}\n"
-        f"- Epistemic history/provenance: {lookup_patterns['epistemic_history']}\n"
-        f"- Workflow details: {lookup_patterns['workflows']}\n"
-        "4) Keep the briefing concise but actionable; avoid ID-only shorthand with no hook.\n\n"
-        f"{living_docs_content}"
-    )
+    briefing_cfg = config.get("briefing", {})
+    custom_prompt = briefing_cfg.get("prompt")
+
+    if custom_prompt:
+        prompt = custom_prompt + "\n\n" + living_docs_content
+    else:
+        prompt = DEFAULT_PROMPT + living_docs_content
+
+    model = config.get("model", "sonnet")
+    agent_cmd = config.get("agent_command")
+    if agent_cmd:
+        cmd = agent_cmd.split()
+    else:
+        cmd = ["claude", "--print", "--model", model]
+
+    cmd.append(prompt)
 
     try:
         result = subprocess.run(
-            ["claude", "--print", "--model", "haiku", prompt],
+            cmd,
             capture_output=True,
             text=True,
             cwd=str(project_root),
-            timeout=120,
+            timeout=300,
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        log.warning("L0 briefing generation failed")
+        if result.returncode != 0:
+            log.warning(
+                "L0 briefing agent failed (rc=%d): %s",
+                result.returncode,
+                result.stderr[:300],
+            )
+    except subprocess.TimeoutExpired:
+        log.warning("L0 briefing generation timed out (300s)")
+    except FileNotFoundError:
+        log.warning("Agent command not found: %s", cmd[0])
 
     return None
-
-
-def _build_lookup_patterns(doc_paths: dict[str, Path], project_root: Path) -> dict[str, str]:
-    """Build per-ID file lookup patterns for L0 briefing instructions."""
-    concepts = _to_repo_relative(doc_paths["concepts"], project_root).with_suffix("")
-    epistemic = _to_repo_relative(doc_paths["epistemic"], project_root).with_suffix("")
-    workflows = _to_repo_relative(doc_paths["workflows"], project_root).with_suffix("")
-    return {
-        "concepts": f"{concepts}/current/C###.md",
-        "epistemic_current": f"{epistemic}/current/E###.md",
-        "epistemic_history": f"{epistemic}/history/E###.md",
-        "workflows": f"{workflows}/current/W###.md",
-    }
 
 
 def _to_repo_relative(path: Path, project_root: Path) -> Path:
@@ -132,8 +163,6 @@ def _to_repo_relative(path: Path, project_root: Path) -> Path:
     try:
         return Path(os.path.relpath(resolved_path, resolved_root))
     except ValueError:
-        # Fallback for cross-drive/path-layout edge cases: strip root so
-        # generated hooks remain portable and non-absolute.
         return Path(*resolved_path.parts[1:]) if resolved_path.is_absolute() else resolved_path
 
 
@@ -148,12 +177,10 @@ def _inject_section(file_path: Path, section_header: str, content: str) -> None:
 
     start = text.find(section_header)
     if start == -1:
-        # Append section at end
         if not text.endswith("\n"):
             text += "\n"
         text += f"\n{section_header}\n\n{content}\n"
     else:
-        # Find the end of this section (next same-level or higher heading)
         section_start = start + len(section_header)
         rest = text[section_start:]
         end_offset = len(rest)

--- a/tests/test_l0_drain.py
+++ b/tests/test_l0_drain.py
@@ -519,13 +519,17 @@ class TestRegenerateL0Briefing:
         result = _generate_briefing(config, project, "### Concepts\nx")
         assert result == "Briefing"
 
-        prompt = mock_run.call_args.args[0][-1]
+        # Prompt passed via stdin (input=), not as argv
+        prompt = mock_run.call_args.kwargs.get("input", "")
         assert "executive briefing" in prompt
         assert "DO NOT INCLUDE" in prompt
         assert "Engram concept IDs" in prompt
         # Old prompt artifacts should be gone
         assert "Lookup Hooks (Use When Needed)" not in prompt
         assert "short inline gloss" not in prompt
+        # Argv ends with "-" (stdin marker), not the full prompt
+        cmd = mock_run.call_args.args[0]
+        assert cmd[-1] == "-"
 
     @patch("engram.server.briefing.subprocess.run")
     def test_generate_briefing_uses_custom_prompt(self, mock_run: MagicMock, project: Path, config: dict) -> None:
@@ -537,7 +541,7 @@ class TestRegenerateL0Briefing:
         result = _generate_briefing(config, project, "### Concepts\ndata")
         assert result == "Custom result"
 
-        prompt = mock_run.call_args.args[0][-1]
+        prompt = mock_run.call_args.kwargs.get("input", "")
         assert prompt.startswith("Custom prompt for this project.")
         assert "### Concepts\ndata" in prompt
 

--- a/tests/test_l0_drain.py
+++ b/tests/test_l0_drain.py
@@ -481,55 +481,88 @@ class TestRegenerateL0Briefing:
         doc_paths = resolve_doc_paths(config, project)
         assert regenerate_l0_briefing(config, project, doc_paths) is False
 
-    def test_build_lookup_patterns(self, project: Path, config: dict) -> None:
+    def test_read_living_docs_skips_timeline(self, project: Path, config: dict) -> None:
+        """Timeline is skipped — too large, mostly historical narrative."""
         from engram.config import resolve_doc_paths
-        from engram.server.briefing import _build_lookup_patterns
+        from engram.server.briefing import _read_living_docs
 
         doc_paths = resolve_doc_paths(config, project)
-        patterns = _build_lookup_patterns(doc_paths, project)
-        assert patterns["concepts"] == "docs/decisions/concept_registry/current/C###.md"
-        assert patterns["epistemic_current"] == "docs/decisions/epistemic_state/current/E###.md"
-        assert patterns["epistemic_history"] == "docs/decisions/epistemic_state/history/E###.md"
-        assert patterns["workflows"] == "docs/decisions/workflow_registry/current/W###.md"
+        # Write substantial content to timeline to verify it's skipped
+        (project / "docs" / "decisions" / "timeline.md").write_text("# Timeline\n" + "x" * 50_000)
+        contents = _read_living_docs(doc_paths)
+        joined = "\n".join(contents)
+        assert "Timeline" not in joined
+        assert "Concepts" in joined
+        assert "Epistemic" in joined
+        assert "Workflows" in joined
 
-    def test_lookup_patterns_stay_relative_for_external_doc_paths(self, project: Path) -> None:
-        from engram.server.briefing import _build_lookup_patterns
+    def test_read_living_docs_no_truncation(self, project: Path, config: dict) -> None:
+        """Concept/epistemic/workflow docs are read in full, not truncated."""
+        from engram.config import resolve_doc_paths
+        from engram.server.briefing import _read_living_docs
 
-        external_root = project.parent / "external_docs"
-        external_root.mkdir(exist_ok=True)
-        external_concepts = external_root / "concept_registry.md"
-        external_concepts.write_text("# Concept Registry\n")
-
-        doc_paths = {
-            "concepts": external_concepts,
-            "epistemic": project / "docs" / "decisions" / "epistemic_state.md",
-            "workflows": project / "docs" / "decisions" / "workflow_registry.md",
-            "timeline": project / "docs" / "decisions" / "timeline.md",
-        }
-
-        patterns = _build_lookup_patterns(doc_paths, project)
-        assert not Path(patterns["concepts"]).is_absolute()
-        assert patterns["concepts"].startswith("../")
+        doc_paths = resolve_doc_paths(config, project)
+        large_content = "# Epistemic State\n" + "claim " * 20_000
+        (project / "docs" / "decisions" / "epistemic_state.md").write_text(large_content)
+        contents = _read_living_docs(doc_paths)
+        joined = "\n".join(contents)
+        # Full content present — no "[... truncated ...]"
+        assert "truncated" not in joined
+        assert "claim " * 100 in joined
 
     @patch("engram.server.briefing.subprocess.run")
-    def test_generate_briefing_prompt_includes_lookup_hooks(self, mock_run: MagicMock, project: Path, config: dict) -> None:
+    def test_generate_briefing_uses_executive_prompt(self, mock_run: MagicMock, project: Path, config: dict) -> None:
         from engram.server.briefing import _generate_briefing
 
         mock_run.return_value = MagicMock(returncode=0, stdout="Briefing")
-        lookup_patterns = {
-            "concepts": "docs/decisions/concept_registry/current/C###.md",
-            "epistemic_current": "docs/decisions/epistemic_state/current/E###.md",
-            "epistemic_history": "docs/decisions/epistemic_state/history/E###.md",
-            "workflows": "docs/decisions/workflow_registry/current/W###.md",
-        }
 
-        result = _generate_briefing(config, project, "### Timeline\nx", lookup_patterns)
+        result = _generate_briefing(config, project, "### Concepts\nx")
         assert result == "Briefing"
 
         prompt = mock_run.call_args.args[0][-1]
-        assert "Lookup Hooks (Use When Needed)" in prompt
-        assert "short inline gloss" in prompt
-        assert lookup_patterns["concepts"] in prompt
-        assert lookup_patterns["epistemic_current"] in prompt
-        assert lookup_patterns["epistemic_history"] in prompt
-        assert lookup_patterns["workflows"] in prompt
+        assert "executive briefing" in prompt
+        assert "DO NOT INCLUDE" in prompt
+        assert "Engram concept IDs" in prompt
+        # Old prompt artifacts should be gone
+        assert "Lookup Hooks (Use When Needed)" not in prompt
+        assert "short inline gloss" not in prompt
+
+    @patch("engram.server.briefing.subprocess.run")
+    def test_generate_briefing_uses_custom_prompt(self, mock_run: MagicMock, project: Path, config: dict) -> None:
+        from engram.server.briefing import _generate_briefing
+
+        config["briefing"]["prompt"] = "Custom prompt for this project."
+        mock_run.return_value = MagicMock(returncode=0, stdout="Custom result")
+
+        result = _generate_briefing(config, project, "### Concepts\ndata")
+        assert result == "Custom result"
+
+        prompt = mock_run.call_args.args[0][-1]
+        assert prompt.startswith("Custom prompt for this project.")
+        assert "### Concepts\ndata" in prompt
+
+    @patch("engram.server.briefing.subprocess.run")
+    def test_generate_briefing_uses_agent_command(self, mock_run: MagicMock, project: Path, config: dict) -> None:
+        from engram.server.briefing import _generate_briefing
+
+        config["agent_command"] = "claude --dangerously-skip-permissions --print --model sonnet"
+        mock_run.return_value = MagicMock(returncode=0, stdout="Result")
+
+        _generate_briefing(config, project, "content")
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "claude"
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--model" in cmd
+
+    @patch("engram.server.briefing.subprocess.run")
+    def test_generate_briefing_uses_config_model(self, mock_run: MagicMock, project: Path, config: dict) -> None:
+        from engram.server.briefing import _generate_briefing
+
+        config["model"] = "opus"
+        mock_run.return_value = MagicMock(returncode=0, stdout="Result")
+
+        _generate_briefing(config, project, "content")
+
+        cmd = mock_run.call_args.args[0]
+        assert "opus" in cmd


### PR DESCRIPTION
Fixes #91

## Summary
- Replace 10K-char truncation with full reads (skip timeline, read concepts/epistemic/workflows in full)
- Replace engram-internal prompt (IDs, lookup hooks, alive-vs-dead) with executive briefing prompt focused on operator needs
- Use project's `agent_command`/`model` config instead of hardcoded haiku
- Add `briefing.prompt` config key for per-project prompt customization
- Remove `_build_lookup_patterns` (no longer needed)

## Test plan
- [x] 586/586 tests pass
- [x] New tests: timeline skipped, no truncation, executive prompt content, custom prompt, agent_command/model used