### PR TITLE
feat(#93): add pull request source for fold pipeline

### DIFF
--- a/engram/bootstrap/fold.py
+++ b/engram/bootstrap/fold.py
@@ -20,7 +20,7 @@ from typing import Any
 from engram.config import load_config, resolve_doc_paths
 from engram.dispatch import invoke_agent, read_docs
 from engram.fold.chunker import ChunkResult, cleanup_chunk_context_worktree, next_chunk
-from engram.fold.queue import build_queue, refresh_issue_snapshots
+from engram.fold.queue import build_queue, refresh_issue_snapshots, refresh_pr_snapshots
 from engram.linter import lint_post_dispatch
 from engram.server.briefing import regenerate_l0_briefing
 from engram.server.db import ServerDB
@@ -141,6 +141,12 @@ def forward_fold(
         log.error("Issue refresh failed: %s", refresh_message)
         return False
     log.info("Issue refresh: %s", refresh_message)
+
+    pr_ok, pr_message = refresh_pr_snapshots(config, project_root)
+    if pr_ok:
+        log.info("PR refresh: %s", pr_message)
+    else:
+        log.warning("PR refresh failed: %s — continuing with local snapshots", pr_message)
 
     # Step 1: Build queue (filtered by from_date)
     log.info("Building queue...")

--- a/engram/cli.py
+++ b/engram/cli.py
@@ -70,6 +70,9 @@ briefing:
 sources:
   issues: local_data/issues/
   refresh_issues: true
+  pull_requests: local_data/pull_requests/
+  refresh_pull_requests: true
+  pr_base_branches: []  # empty = all merged PRs; or ["dev", "epic/*"]
   github_repo: null  # Optional explicit owner/repo; else infer from git origin
   docs:
     - docs/working/
@@ -171,7 +174,7 @@ def init(project_root: str) -> None:
 def build_queue_cmd(project_root: str, start_date: object, refresh_issues: bool) -> None:
     """Build chronological queue of all project artifacts."""
     from engram.config import load_config
-    from engram.fold.queue import build_queue, refresh_issue_snapshots
+    from engram.fold.queue import build_queue, refresh_issue_snapshots, refresh_pr_snapshots
     from engram.server.db import ServerDB
 
     root = Path(project_root)
@@ -199,6 +202,12 @@ def build_queue_cmd(project_root: str, start_date: object, refresh_issues: bool)
             )
             raise SystemExit(1)
 
+        pr_ok, pr_message = refresh_pr_snapshots(config, root)
+        if pr_ok:
+            click.echo(f"PR refresh: {pr_message}")
+        else:
+            click.echo(f"PR refresh failed: {pr_message}. Continuing with local snapshots.")
+
     entries = build_queue(config, root, start_date=effective_start)
 
     doc_count = sum(1 for e in entries if e["type"] == "doc")
@@ -206,11 +215,13 @@ def build_queue_cmd(project_root: str, start_date: object, refresh_issues: bool)
         1 for e in entries if e["type"] == "doc" and e["pass"] == "revisit"
     )
     issue_count = sum(1 for e in entries if e["type"] == "issue")
+    pr_count = sum(1 for e in entries if e["type"] == "pr")
     session_count = sum(1 for e in entries if e["type"] == "prompts")
 
     click.echo(f"Built queue: {len(entries)} entries")
     click.echo(f"  Docs: {doc_count} ({revisit_count} revisits)")
     click.echo(f"  Issues: {issue_count}")
+    click.echo(f"  PRs: {pr_count}")
     click.echo(f"  Sessions: {session_count}")
 
     if entries:

--- a/engram/config.py
+++ b/engram/config.py
@@ -27,6 +27,9 @@ DEFAULTS: dict[str, Any] = {
     "sources": {
         "issues": "local_data/issues/",
         "refresh_issues": True,
+        "pull_requests": "local_data/pull_requests/",
+        "refresh_pull_requests": True,
+        "pr_base_branches": [],
         "github_repo": None,
         "docs": ["docs/working/", "docs/archive/", "docs/specs/"],
         "sessions": {

--- a/engram/fold/chunker.py
+++ b/engram/fold/chunker.py
@@ -1386,6 +1386,9 @@ def _render_item_content(item: dict[str, Any], project_root: Path) -> str:
     elif item["type"] == "issue":
         header = f"## [{tag}] Issue #{item['issue_number']}: {item['issue_title']}\n"
         header += f"**Created:** {item['date'][:10]}\n\n"
+    elif item["type"] == "pr":
+        header = f"## [{tag}] PR #{item['pr_number']}: {item['pr_title']}\n"
+        header += f"**Merged:** {item['date'][:10]}\n\n"
     else:
         header = f"## [{tag}] Doc: {item['path']}\n"
         header += f"**Created:** {item['date'][:10]}"
@@ -1403,6 +1406,10 @@ def _render_item_content(item: dict[str, Any], project_root: Path) -> str:
             from engram.fold.sources import render_issue_markdown
             issue_data = json.loads(item_path.read_text())
             content = render_issue_markdown(issue_data)
+        elif item["type"] == "pr":
+            from engram.fold.sources import render_pr_markdown
+            pr_data = json.loads(item_path.read_text())
+            content = render_pr_markdown(pr_data)
         else:
             content = item_path.read_text(errors="ignore")
     except FileNotFoundError:

--- a/engram/fold/queue.py
+++ b/engram/fold/queue.py
@@ -25,7 +25,9 @@ from engram.fold.sources import (
     parse_date,
     parse_frontmatter_date,
     pull_issues,
+    pull_prs,
     render_issue_markdown,
+    render_pr_markdown,
 )
 
 # Dual-pass threshold: if modified > created + this many days, create revisit entry
@@ -60,6 +62,38 @@ def refresh_issue_snapshots(config: dict[str, Any], project_root: Path) -> tuple
         return False, "gh CLI not found while refreshing issues"
 
     return True, f"refreshed {len(issues)} issues from {repo}"
+
+
+def refresh_pr_snapshots(config: dict[str, Any], project_root: Path) -> tuple[bool, str]:
+    """Refresh ``sources.pull_requests`` JSON snapshots from GitHub.
+
+    Returns:
+        (ok, message) where ``ok`` indicates refresh success.
+    """
+    sources = config.get("sources", {})
+    if not sources.get("refresh_pull_requests", True):
+        return True, "disabled by config (sources.refresh_pull_requests: false)"
+
+    prs_dir = project_root / sources.get("pull_requests", "local_data/pull_requests/")
+    repo = sources.get("github_repo") or infer_github_repo(project_root)
+    if not repo:
+        return True, (
+            "unable to resolve GitHub repo (set sources.github_repo or configure "
+            "git remote.origin.url); using local PR snapshots"
+        )
+
+    base_branches = sources.get("pr_base_branches", [])
+
+    try:
+        prs = pull_prs(repo, prs_dir, base_branches or None)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        detail = f": {stderr}" if stderr else ""
+        return False, f"gh pr list failed for {repo}{detail}"
+    except FileNotFoundError:
+        return False, "gh CLI not found while refreshing PRs"
+
+    return True, f"refreshed {len(prs)} PRs from {repo}"
 
 
 def build_queue(
@@ -188,6 +222,32 @@ def build_queue(
                 })
             except (json.JSONDecodeError, KeyError) as exc:
                 logger.warning("Skipping issue %s: %s", f.name, exc)
+
+    # --- Process pull requests ---
+    prs_dir = project_root / sources.get("pull_requests", "local_data/pull_requests/")
+    if prs_dir.exists():
+        for f in sorted(prs_dir.glob("*.json")):
+            try:
+                pr = json.loads(f.read_text())
+                rendered = render_pr_markdown(pr)
+                char_count = len(rendered)
+                rel_path = str(f.relative_to(project_root))
+                sizes[rel_path] = char_count
+
+                # Use mergedAt as the canonical date (when work landed)
+                pr_date = pr.get("mergedAt") or pr.get("createdAt", "")
+
+                entries.append({
+                    "date": pr_date,
+                    "type": "pr",
+                    "path": rel_path,
+                    "chars": char_count,
+                    "pass": "initial",
+                    "pr_number": pr["number"],
+                    "pr_title": pr.get("title", ""),
+                })
+            except (json.JSONDecodeError, KeyError) as exc:
+                logger.warning("Skipping PR %s: %s", f.name, exc)
 
     # --- Process session prompts ---
     fmt = session_cfg.get("format", "claude-code")

--- a/engram/fold/sources.py
+++ b/engram/fold/sources.py
@@ -90,6 +90,16 @@ def pull_prs(
             if _matches_branch_filter(pr.get("baseRefName", ""), base_branches)
         ]
 
+    # Clear stale snapshots so narrowed filters don't leave old PRs on disk
+    matched_numbers = {pr["number"] for pr in prs}
+    for stale in prs_dir.glob("*.json"):
+        try:
+            num = int(stale.stem)
+        except ValueError:
+            continue
+        if num not in matched_numbers:
+            stale.unlink()
+
     for pr in prs:
         num = pr["number"]
         path = prs_dir / f"{num}.json"

--- a/engram/fold/sources.py
+++ b/engram/fold/sources.py
@@ -1,4 +1,4 @@
-"""Source ingestion: issue pulling, git dates, frontmatter parsing.
+"""Source ingestion: issue/PR pulling, git dates, frontmatter parsing.
 
 Ported from v2 (fractal-market-simulator/scripts/knowledge_fold.py)
 with all paths parameterized by config.
@@ -12,6 +12,7 @@ import re
 import subprocess
 from datetime import datetime
 from pathlib import Path
+from fnmatch import fnmatch
 from typing import Iterable
 
 
@@ -46,6 +47,130 @@ def pull_issues(repo: str, issues_dir: Path) -> list[dict]:
         path.write_text(json.dumps(issue, indent=2))
 
     return issues
+
+
+def pull_prs(
+    repo: str,
+    prs_dir: Path,
+    base_branches: list[str] | None = None,
+) -> list[dict]:
+    """Pull merged GitHub PRs with review comments into local JSON files.
+
+    Args:
+        repo: GitHub repo in "owner/repo" format.
+        prs_dir: Directory to write PR JSON files.
+        base_branches: Optional list of base branch filters (supports globs
+            like ``epic/*``). Empty list or None means all merged PRs.
+
+    Returns:
+        List of PR dicts.
+    """
+    prs_dir.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        [
+            "gh", "pr", "list",
+            "--repo", repo,
+            "--state", "merged",
+            "--json", (
+                "number,title,body,createdAt,mergedAt,baseRefName,"
+                "headRefName,additions,deletions,changedFiles,"
+                "reviews,comments,files"
+            ),
+            "--limit", "5000",
+        ],
+        capture_output=True, text=True, check=True,
+    )
+
+    prs = json.loads(result.stdout)
+
+    if base_branches:
+        prs = [
+            pr for pr in prs
+            if _matches_branch_filter(pr.get("baseRefName", ""), base_branches)
+        ]
+
+    for pr in prs:
+        num = pr["number"]
+        path = prs_dir / f"{num}.json"
+        path.write_text(json.dumps(pr, indent=2))
+
+    return prs
+
+
+def _matches_branch_filter(branch: str, patterns: list[str]) -> bool:
+    """Check if a branch name matches any of the given patterns.
+
+    Supports exact match and glob patterns (e.g. ``epic/*``).
+    """
+    return any(fnmatch(branch, pat) for pat in patterns)
+
+
+def render_pr_markdown(pr: dict) -> str:
+    """Render a GitHub PR JSON object as clean markdown."""
+    parts = []
+
+    # Meta line
+    base = pr.get("baseRefName", "?")
+    head = pr.get("headRefName", "?")
+    additions = pr.get("additions", 0)
+    deletions = pr.get("deletions", 0)
+    changed = pr.get("changedFiles", 0)
+    parts.append(f"**Merged** into `{base}` from `{head}`")
+    parts.append(f"**Changes:** +{additions} -{deletions} across {changed} files")
+    parts.append("")
+
+    # Body
+    body = pr.get("body", "") or ""
+    if body:
+        parts.append(body)
+        parts.append("")
+
+    # Changed files list
+    files = pr.get("files", [])
+    if files:
+        parts.append("### Files changed")
+        parts.append("")
+        for f in files:
+            path = f.get("path", "")
+            add = f.get("additions", 0)
+            dele = f.get("deletions", 0)
+            parts.append(f"- `{path}` (+{add} -{dele})")
+        parts.append("")
+
+    # Review comments
+    reviews = pr.get("reviews", [])
+    review_comments = [
+        r for r in reviews
+        if r.get("body", "").strip()
+    ]
+    if review_comments:
+        parts.append("### Reviews")
+        parts.append("")
+        for review in review_comments:
+            author = review.get("author", {}).get("login", "unknown")
+            state = review.get("state", "")
+            rbody = review.get("body", "")
+            parts.append(f"**{author}** ({state}):")
+            parts.append("")
+            parts.append(rbody)
+            parts.append("")
+
+    # PR-level comments (conversation)
+    comments = pr.get("comments", [])
+    if comments:
+        parts.append("### Comments")
+        parts.append("")
+        for comment in comments:
+            author = comment.get("author", {}).get("login", "unknown")
+            date = comment.get("createdAt", "")[:10]
+            cbody = comment.get("body", "")
+            parts.append(f"**{author}** ({date}):")
+            parts.append("")
+            parts.append(cbody)
+            parts.append("")
+
+    return "\n".join(parts)
 
 
 def infer_github_repo(project_root: Path) -> str | None:

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1272,6 +1272,42 @@ class TestRenderItemContent:
         result = _render_item_content(item, project)
         assert "Issue #42: Fix bug" in result
 
+    def test_pr_item(self, project):
+        pr_dir = project / "local_data" / "pull_requests"
+        pr_dir.mkdir(parents=True)
+        pr_data = {
+            "number": 100,
+            "title": "Fix the perf bug",
+            "body": "Optimized the hot path.",
+            "createdAt": "2026-03-01T00:00:00Z",
+            "mergedAt": "2026-03-02T10:00:00Z",
+            "baseRefName": "epic/1808",
+            "headRefName": "fix/100",
+            "additions": 20,
+            "deletions": 5,
+            "changedFiles": 2,
+            "files": [{"path": "src/main.py", "additions": 15, "deletions": 3}],
+            "reviews": [],
+            "comments": [],
+        }
+        (pr_dir / "100.json").write_text(json.dumps(pr_data))
+
+        item = {
+            "date": "2026-03-02T10:00:00Z",
+            "type": "pr",
+            "path": "local_data/pull_requests/100.json",
+            "chars": 500,
+            "pass": "initial",
+            "pr_number": 100,
+            "pr_title": "Fix the perf bug",
+        }
+        result = _render_item_content(item, project)
+        assert "PR #100: Fix the perf bug" in result
+        assert "Merged:" in result
+        assert "epic/1808" in result
+        assert "Optimized the hot path." in result
+        assert "`src/main.py`" in result
+
     def test_missing_file_graceful(self, project):
         item = _make_doc_item(path="nonexistent.md")
         result = _render_item_content(item, project)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 
 from engram.config import DEFAULTS, _deep_merge
-from engram.fold.queue import REVISIT_THRESHOLD_DAYS, build_queue, refresh_issue_snapshots
+from engram.fold.queue import REVISIT_THRESHOLD_DAYS, build_queue, refresh_issue_snapshots, refresh_pr_snapshots
 
 
 @pytest.fixture
@@ -154,6 +154,143 @@ class TestBuildQueueIssues:
         assert issue_entries[0]["issue_number"] == 42
         assert issue_entries[0]["issue_title"] == "Bug report"
         assert issue_entries[0]["date"] == "2026-01-10T12:00:00Z"
+
+
+class TestBuildQueuePRs:
+    def test_includes_pr_entries(self, project: Path) -> None:
+        prs_dir = project / "local_data" / "pull_requests"
+        prs_dir.mkdir(parents=True)
+
+        pr = {
+            "number": 100,
+            "title": "Fix the thing",
+            "body": "Detailed fix description.",
+            "createdAt": "2026-03-01T00:00:00Z",
+            "mergedAt": "2026-03-02T10:00:00Z",
+            "baseRefName": "dev",
+            "headRefName": "fix/100",
+            "additions": 20,
+            "deletions": 5,
+            "changedFiles": 2,
+            "files": [],
+            "reviews": [],
+            "comments": [],
+        }
+        (prs_dir / "100.json").write_text(json.dumps(pr))
+
+        config = _make_config(project, {
+            "sources": {"pull_requests": "local_data/pull_requests/"},
+        })
+
+        with patch("engram.fold.sources.subprocess.run", side_effect=_mock_git_run):
+            entries = build_queue(config, project)
+
+        pr_entries = [e for e in entries if e["type"] == "pr"]
+        assert len(pr_entries) == 1
+        assert pr_entries[0]["pr_number"] == 100
+        assert pr_entries[0]["pr_title"] == "Fix the thing"
+        # Uses mergedAt as the canonical date
+        assert pr_entries[0]["date"] == "2026-03-02T10:00:00Z"
+
+    def test_pr_uses_created_at_when_no_merged_at(self, project: Path) -> None:
+        prs_dir = project / "local_data" / "pull_requests"
+        prs_dir.mkdir(parents=True)
+
+        pr = {
+            "number": 200,
+            "title": "WIP PR",
+            "body": "",
+            "createdAt": "2026-03-05T00:00:00Z",
+            "mergedAt": None,
+            "baseRefName": "dev",
+            "headRefName": "wip/200",
+            "additions": 0,
+            "deletions": 0,
+            "changedFiles": 0,
+            "files": [],
+            "reviews": [],
+            "comments": [],
+        }
+        (prs_dir / "200.json").write_text(json.dumps(pr))
+
+        config = _make_config(project, {
+            "sources": {"pull_requests": "local_data/pull_requests/"},
+        })
+
+        with patch("engram.fold.sources.subprocess.run", side_effect=_mock_git_run):
+            entries = build_queue(config, project)
+
+        pr_entries = [e for e in entries if e["type"] == "pr"]
+        assert len(pr_entries) == 1
+        assert pr_entries[0]["date"] == "2026-03-05T00:00:00Z"
+
+    def test_pr_filtered_by_start_date(self, project: Path) -> None:
+        prs_dir = project / "local_data" / "pull_requests"
+        prs_dir.mkdir(parents=True)
+
+        for num, merged in [(1, "2025-12-01T00:00:00Z"), (2, "2026-03-01T00:00:00Z")]:
+            pr = {
+                "number": num,
+                "title": f"PR {num}",
+                "body": "",
+                "createdAt": merged,
+                "mergedAt": merged,
+                "baseRefName": "dev",
+                "headRefName": f"fix/{num}",
+                "additions": 0,
+                "deletions": 0,
+                "changedFiles": 0,
+                "files": [],
+                "reviews": [],
+                "comments": [],
+            }
+            (prs_dir / f"{num}.json").write_text(json.dumps(pr))
+
+        config = _make_config(project, {
+            "sources": {"pull_requests": "local_data/pull_requests/"},
+        })
+
+        with patch("engram.fold.sources.subprocess.run", side_effect=_mock_git_run):
+            entries = build_queue(config, project, start_date="2026-01-01")
+
+        pr_entries = [e for e in entries if e["type"] == "pr"]
+        assert len(pr_entries) == 1
+        assert pr_entries[0]["pr_number"] == 2
+
+
+class TestPRRefresh:
+    def test_refresh_uses_explicit_repo(self, project: Path) -> None:
+        config = _make_config(project, {"sources": {"github_repo": "owner/repo"}})
+
+        with patch("engram.fold.queue.pull_prs", return_value=[{"number": 1}]) as mock_pull:
+            ok, message = refresh_pr_snapshots(config, project)
+
+        assert ok is True
+        assert "refreshed 1 PRs from owner/repo" in message
+
+    def test_refresh_disabled_by_config(self, project: Path) -> None:
+        config = _make_config(project, {
+            "sources": {"refresh_pull_requests": False},
+        })
+
+        ok, message = refresh_pr_snapshots(config, project)
+        assert ok is True
+        assert "disabled" in message
+
+    def test_refresh_returns_failure_when_gh_fails(self, project: Path) -> None:
+        config = _make_config(project, {"sources": {"github_repo": "owner/repo"}})
+
+        called_process_error = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["gh", "pr", "list"],
+            stderr="authentication failed",
+        )
+
+        with patch("engram.fold.queue.pull_prs", side_effect=called_process_error):
+            ok, message = refresh_pr_snapshots(config, project)
+
+        assert ok is False
+        assert "gh pr list failed" in message
 
 
 class TestBuildQueueSessions:

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -229,6 +229,24 @@ class TestPullPrs:
         assert len(result) == 2
         assert {pr["number"] for pr in result} == {2, 3}
 
+    def test_purges_stale_snapshots(self, tmp_path: Path) -> None:
+        prs_dir = tmp_path / "prs"
+        prs_dir.mkdir()
+        # Pre-existing snapshot from a PR that won't be in the new fetch
+        (prs_dir / "99.json").write_text('{"number": 99}')
+
+        mock_prs = [
+            {"number": 1, "baseRefName": "dev", "title": "Current"},
+        ]
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(mock_prs)
+        )
+        with patch("engram.fold.sources.subprocess.run", return_value=mock_result):
+            pull_prs("owner/repo", prs_dir)
+
+        assert (prs_dir / "1.json").exists()
+        assert not (prs_dir / "99.json").exists()
+
     def test_empty_base_branches_returns_all(self, tmp_path: Path) -> None:
         mock_prs = [
             {"number": 1, "baseRefName": "dev"},

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -10,13 +10,16 @@ from unittest.mock import patch
 import pytest
 
 from engram.fold.sources import (
+    _matches_branch_filter,
     extract_issue_number,
     git_diff_summary,
     get_doc_git_dates,
     parse_date,
     parse_frontmatter_date,
     pull_issues,
+    pull_prs,
     render_issue_markdown,
+    render_pr_markdown,
 )
 
 
@@ -71,6 +74,190 @@ class TestRenderIssueMarkdown:
         }
         result = render_issue_markdown(issue)
         assert "bug, priority" in result
+
+
+class TestRenderPrMarkdown:
+    def test_basic_pr(self) -> None:
+        pr = {
+            "baseRefName": "dev",
+            "headRefName": "feature/123-fix",
+            "additions": 50,
+            "deletions": 10,
+            "changedFiles": 3,
+            "body": "Fixed the bug.",
+            "files": [],
+            "reviews": [],
+            "comments": [],
+        }
+        result = render_pr_markdown(pr)
+        assert "**Merged** into `dev` from `feature/123-fix`" in result
+        assert "+50 -10 across 3 files" in result
+        assert "Fixed the bug." in result
+
+    def test_with_files(self) -> None:
+        pr = {
+            "baseRefName": "dev",
+            "headRefName": "fix/abc",
+            "additions": 20,
+            "deletions": 5,
+            "changedFiles": 2,
+            "body": "",
+            "files": [
+                {"path": "src/main.py", "additions": 15, "deletions": 3},
+                {"path": "tests/test_main.py", "additions": 5, "deletions": 2},
+            ],
+            "reviews": [],
+            "comments": [],
+        }
+        result = render_pr_markdown(pr)
+        assert "### Files changed" in result
+        assert "`src/main.py` (+15 -3)" in result
+        assert "`tests/test_main.py` (+5 -2)" in result
+
+    def test_with_reviews(self) -> None:
+        pr = {
+            "baseRefName": "epic/1808",
+            "headRefName": "feature/fix",
+            "additions": 10,
+            "deletions": 0,
+            "changedFiles": 1,
+            "body": "PR body.",
+            "files": [],
+            "reviews": [
+                {
+                    "author": {"login": "reviewer1"},
+                    "state": "APPROVED",
+                    "body": "LGTM",
+                },
+                {
+                    "author": {"login": "bot"},
+                    "state": "COMMENTED",
+                    "body": "",  # empty body — should be filtered
+                },
+            ],
+            "comments": [],
+        }
+        result = render_pr_markdown(pr)
+        assert "### Reviews" in result
+        assert "**reviewer1** (APPROVED):" in result
+        assert "LGTM" in result
+        # Empty review body should not appear
+        assert "bot" not in result
+
+    def test_with_comments(self) -> None:
+        pr = {
+            "baseRefName": "dev",
+            "headRefName": "feature/x",
+            "additions": 1,
+            "deletions": 0,
+            "changedFiles": 1,
+            "body": "",
+            "files": [],
+            "reviews": [],
+            "comments": [
+                {
+                    "author": {"login": "alice"},
+                    "createdAt": "2026-03-10T12:00:00Z",
+                    "body": "Can we add a test?",
+                }
+            ],
+        }
+        result = render_pr_markdown(pr)
+        assert "### Comments" in result
+        assert "**alice** (2026-03-10):" in result
+        assert "Can we add a test?" in result
+
+    def test_none_body(self) -> None:
+        pr = {
+            "baseRefName": "dev",
+            "headRefName": "fix/y",
+            "additions": 0,
+            "deletions": 0,
+            "changedFiles": 0,
+            "body": None,
+            "files": [],
+            "reviews": [],
+            "comments": [],
+        }
+        result = render_pr_markdown(pr)
+        assert "**Merged**" in result
+
+
+class TestPullPrs:
+    def test_writes_pr_files(self, tmp_path: Path) -> None:
+        mock_prs = [
+            {
+                "number": 100,
+                "title": "Fix bug",
+                "body": "Fixed",
+                "createdAt": "2026-03-01T00:00:00Z",
+                "mergedAt": "2026-03-02T00:00:00Z",
+                "baseRefName": "dev",
+                "headRefName": "fix/100",
+                "additions": 10,
+                "deletions": 2,
+                "changedFiles": 1,
+                "files": [],
+                "reviews": [],
+                "comments": [],
+            },
+        ]
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(mock_prs)
+        )
+        with patch("engram.fold.sources.subprocess.run", return_value=mock_result):
+            prs_dir = tmp_path / "prs"
+            result = pull_prs("owner/repo", prs_dir)
+
+        assert len(result) == 1
+        assert (prs_dir / "100.json").exists()
+
+    def test_filters_by_base_branch(self, tmp_path: Path) -> None:
+        mock_prs = [
+            {"number": 1, "baseRefName": "dev", "title": "To dev"},
+            {"number": 2, "baseRefName": "epic/1808", "title": "To epic"},
+            {"number": 3, "baseRefName": "epic/2040", "title": "To epic 2"},
+            {"number": 4, "baseRefName": "main", "title": "To main"},
+        ]
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(mock_prs)
+        )
+        with patch("engram.fold.sources.subprocess.run", return_value=mock_result):
+            prs_dir = tmp_path / "prs"
+            result = pull_prs("owner/repo", prs_dir, base_branches=["epic/*"])
+
+        assert len(result) == 2
+        assert {pr["number"] for pr in result} == {2, 3}
+
+    def test_empty_base_branches_returns_all(self, tmp_path: Path) -> None:
+        mock_prs = [
+            {"number": 1, "baseRefName": "dev"},
+            {"number": 2, "baseRefName": "epic/1808"},
+        ]
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(mock_prs)
+        )
+        with patch("engram.fold.sources.subprocess.run", return_value=mock_result):
+            prs_dir = tmp_path / "prs"
+            result = pull_prs("owner/repo", prs_dir, base_branches=None)
+
+        assert len(result) == 2
+
+
+class TestMatchesBranchFilter:
+    def test_exact_match(self) -> None:
+        assert _matches_branch_filter("dev", ["dev"]) is True
+
+    def test_glob_match(self) -> None:
+        assert _matches_branch_filter("epic/1808", ["epic/*"]) is True
+        assert _matches_branch_filter("epic/2040", ["epic/*"]) is True
+
+    def test_no_match(self) -> None:
+        assert _matches_branch_filter("main", ["dev", "epic/*"]) is False
+
+    def test_multiple_patterns(self) -> None:
+        assert _matches_branch_filter("dev", ["dev", "epic/*"]) is True
+        assert _matches_branch_filter("epic/1808", ["dev", "epic/*"]) is True
 
 
 class TestParseFrontmatterDate:


### PR DESCRIPTION
## Summary

- Adds `pull_prs()` + `render_pr_markdown()` to ingest merged PRs as fold artifacts
- New config keys: `pull_requests`, `refresh_pull_requests`, `pr_base_branches`
- `pr_base_branches` supports glob patterns (e.g., `epic/*`) for filtering by target branch
- PRs are dated by `mergedAt` (when work landed), falling back to `createdAt`
- PR rendering includes: body, files changed, review comments, conversation comments
- 22 new tests across `test_sources.py` and `test_queue.py`
- All 604 tests pass

## Motivation

The fold pipeline ingested issues, docs, and sessions — but not pull requests. PRs contain the actual engineering context (specs, review discussion, diff summaries). With the shift to epic-branch workflow (feature → PR → epic → PR → dev), individual PRs are invisible until the epic merges, losing all granularity.

## Test plan

- [x] `render_pr_markdown` — body, files, reviews, comments, edge cases (None body, empty reviews)
- [x] `pull_prs` — file writing, base branch filtering, empty filter returns all
- [x] `_matches_branch_filter` — exact, glob, no match, multiple patterns
- [x] `build_queue` PR integration — entry creation, mergedAt dating, start_date filtering
- [x] `refresh_pr_snapshots` — success, disabled, gh failure
- [x] Full suite: 604 passed

Fixes #93