### PR TITLE
G: engram stats --json

### DIFF
--- a/engram/cli.py
+++ b/engram/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+import json
 from pathlib import Path
 
 import click
@@ -538,6 +539,101 @@ def _cleanup_chunk_context_from_lock(project_root: Path, lock: dict) -> None:
     cleanup_chunk_context_worktree(project_root, Path(raw))
 
 
+def _emit_json(payload: object) -> None:
+    """Print a JSON payload for CLI consumers."""
+    click.echo(json.dumps(payload, indent=2, sort_keys=True, default=str))
+
+
+def _utcnow() -> "datetime":
+    """Return the current UTC timestamp."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc)
+
+
+def _parse_timestamp(raw: str) -> "datetime":
+    """Parse an ISO timestamp into an aware UTC datetime."""
+    from datetime import datetime, timezone
+
+    return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _collect_concept_counts(project_root: Path, config: dict) -> dict[str, int]:
+    """Count active and inactive concepts from the concept registry."""
+    from engram.config import resolve_doc_paths
+    from engram.parse import extract_id, parse_sections
+
+    counts = {
+        "active_concepts": 0,
+        "dead_concepts": 0,
+    }
+
+    concepts_path = resolve_doc_paths(config, project_root)["concepts"]
+    if not concepts_path.exists():
+        return counts
+
+    for section in parse_sections(concepts_path.read_text()):
+        entry_id = extract_id(section["heading"])
+        if not entry_id or not entry_id.startswith("C"):
+            continue
+
+        heading = section["heading"].upper()
+        if "(DEAD" in heading or "(EVOLVED" in heading:
+            counts["dead_concepts"] += 1
+        else:
+            counts["active_concepts"] += 1
+
+    return counts
+
+
+def _collect_stats(project_root: Path, config: dict) -> dict[str, object]:
+    """Collect fold telemetry and concept health stats."""
+    from datetime import timedelta
+
+    from engram.server.buffer import ContextBuffer
+    from engram.server.db import ServerDB
+
+    db_path = project_root / ".engram" / "engram.db"
+    now = _utcnow()
+
+    if db_path.exists():
+        db = ServerDB(db_path)
+        fold_metrics = db.get_fold_telemetry(
+            since_7d=(now - timedelta(days=7)).isoformat(),
+            since_30d=(now - timedelta(days=30)).isoformat(),
+        )
+        buffer = ContextBuffer(config, project_root, db).get_fill_info()
+    else:
+        fold_metrics = {
+            "last_fold_at": None,
+            "folds_last_7d": 0,
+            "folds_last_30d": 0,
+        }
+        buffer = {
+            "fill_pct": 0.0,
+            "item_count": 0,
+        }
+
+    last_fold_at = fold_metrics["last_fold_at"]
+    last_fold_age_hours = None
+    if isinstance(last_fold_at, str):
+        last_fold_age_hours = round(
+            max((now - _parse_timestamp(last_fold_at)).total_seconds(), 0.0) / 3600,
+            1,
+        )
+
+    stats = {
+        "last_fold_at": last_fold_at,
+        "last_fold_age_hours": last_fold_age_hours,
+        "folds_last_7d": fold_metrics["folds_last_7d"],
+        "folds_last_30d": fold_metrics["folds_last_30d"],
+        "buffer_fill_pct": float(buffer["fill_pct"]),
+        "buffer_items": int(buffer["item_count"]),
+    }
+    stats.update(_collect_concept_counts(project_root, config))
+    return stats
+
+
 @cli.command()
 @click.option(
     "--project-root",
@@ -683,7 +779,13 @@ def run(project_root: str) -> None:
     default=".",
     help="Project root directory (default: cwd).",
 )
-def status(project_root: str) -> None:
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output status as JSON.",
+)
+def status(project_root: str, as_json: bool) -> None:
     """Show engram server status."""
     from engram.config import load_config
     from engram.server import get_status
@@ -693,8 +795,15 @@ def status(project_root: str) -> None:
     info = get_status(config, root)
 
     if "error" in info:
-        click.echo(f"Error: {info['error']}")
+        if as_json:
+            _emit_json(info)
+        else:
+            click.echo(f"Error: {info['error']}")
         raise SystemExit(1)
+
+    if as_json:
+        _emit_json(info)
+        return
 
     # Buffer
     buf = info["buffer"]
@@ -736,6 +845,46 @@ def status(project_root: str) -> None:
         click.echo(f"\nLast poll: {state['last_poll_time']}")
     if state.get("last_dispatch_time"):
         click.echo(f"Last dispatch: {state['last_dispatch_time']}")
+
+
+@cli.command()
+@click.option(
+    "--project-root",
+    type=click.Path(exists=True, file_okay=False, resolve_path=True),
+    default=".",
+    help="Project root directory (default: cwd).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output stats as JSON.",
+)
+def stats(project_root: str, as_json: bool) -> None:
+    """Show fold telemetry and concept registry health stats."""
+    from engram.config import load_config
+
+    root = Path(project_root)
+    config = load_config(root)
+    payload = _collect_stats(root, config)
+
+    if as_json:
+        _emit_json(payload)
+        return
+
+    click.echo("Fold telemetry:")
+    click.echo(f"  Last fold: {payload['last_fold_at'] or 'None'}")
+    click.echo(f"  Last fold age (hours): {payload['last_fold_age_hours']}")
+    click.echo(f"  Folds last 7d: {payload['folds_last_7d']}")
+    click.echo(f"  Folds last 30d: {payload['folds_last_30d']}")
+
+    click.echo("\nConcept registry:")
+    click.echo(f"  Active concepts: {payload['active_concepts']}")
+    click.echo(f"  Dead concepts: {payload['dead_concepts']}")
+
+    click.echo("\nBuffer:")
+    click.echo(f"  Fill %: {payload['buffer_fill_pct']}")
+    click.echo(f"  Items: {payload['buffer_items']}")
 
 
 @cli.command()

--- a/engram/server/db.py
+++ b/engram/server/db.py
@@ -405,6 +405,37 @@ class ServerDB:
         finally:
             conn.close()
 
+    def get_fold_telemetry(
+        self,
+        since_7d: str,
+        since_30d: str,
+    ) -> dict[str, Any]:
+        """Return committed-fold telemetry for machine-readable stats output."""
+        conn = self._connect()
+        try:
+            row = conn.execute("""
+                SELECT
+                    MAX(CASE WHEN state = 'committed' THEN updated_at END) AS last_fold_at,
+                    COALESCE(
+                        SUM(CASE WHEN state = 'committed' AND updated_at >= ? THEN 1 ELSE 0 END),
+                        0
+                    ) AS folds_last_7d,
+                    COALESCE(
+                        SUM(CASE WHEN state = 'committed' AND updated_at >= ? THEN 1 ELSE 0 END),
+                        0
+                    ) AS folds_last_30d
+                FROM dispatches
+            """, (since_7d, since_30d)).fetchone()
+            if row is None:
+                return {
+                    "last_fold_at": None,
+                    "folds_last_7d": 0,
+                    "folds_last_30d": 0,
+                }
+            return dict(row)
+        finally:
+            conn.close()
+
     # ------------------------------------------------------------------
     # Server state
     # ------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import tempfile
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from pathlib import Path
 from unittest.mock import patch
@@ -131,6 +133,84 @@ class TestBuildQueueCommand:
 
         assert result.exit_code == 0
         mock_refresh.assert_not_called()
+
+
+class TestJsonCommands:
+    def test_stats_json_reports_fold_telemetry_and_status_json(
+        self, runner: CliRunner, project_dir: Path,
+    ) -> None:
+        from engram.server.db import ServerDB
+
+        init_result = runner.invoke(cli, ["init", "--project-root", str(project_dir)])
+        assert init_result.exit_code == 0
+
+        concepts = project_dir / "docs" / "decisions" / "concept_registry.md"
+        concepts.write_text(
+            "# Concept Registry\n\n"
+            "## C001: Active concept (ACTIVE)\n"
+            "**Code:** `engram/cli.py`\n\n"
+            "## C002: Old concept (DEAD) → concept_graveyard.md#C002\n",
+        )
+
+        db = ServerDB(project_dir / ".engram" / "engram.db")
+        committed_recent = db.create_dispatch(chunk_id=1)
+        db.update_dispatch_state(committed_recent, "committed")
+        committed_older = db.create_dispatch(chunk_id=2)
+        db.update_dispatch_state(committed_older, "committed")
+        db.create_dispatch(chunk_id=3)
+        db.add_buffer_item("docs/working/a.md", "doc", chars=42, date="2026-03-01T00:00:00Z")
+
+        now = datetime.now(timezone.utc)
+        recent_fold_at = now - timedelta(hours=2)
+        older_fold_at = now - timedelta(days=3)
+        with sqlite3.connect(project_dir / ".engram" / "engram.db") as conn:
+            conn.execute(
+                "UPDATE dispatches SET created_at = ?, updated_at = ? WHERE id = ?",
+                (recent_fold_at.isoformat(), recent_fold_at.isoformat(), committed_recent),
+            )
+            conn.execute(
+                "UPDATE dispatches SET created_at = ?, updated_at = ? WHERE id = ?",
+                (older_fold_at.isoformat(), older_fold_at.isoformat(), committed_older),
+            )
+            conn.commit()
+
+        result = runner.invoke(cli, ["stats", "--project-root", str(project_dir), "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["last_fold_at"] == recent_fold_at.isoformat()
+        assert 1.9 <= payload["last_fold_age_hours"] <= 2.1
+        assert payload["folds_last_7d"] == 2
+        assert payload["folds_last_30d"] == 2
+        assert payload["active_concepts"] == 1
+        assert payload["dead_concepts"] == 1
+        assert payload["buffer_items"] == 1
+        assert payload["buffer_fill_pct"] > 0
+
+        status_result = runner.invoke(cli, ["status", "--project-root", str(project_dir), "--json"])
+        assert status_result.exit_code == 0
+        status_payload = json.loads(status_result.output)
+        assert status_payload["buffer"]["item_count"] == 1
+        assert status_payload["last_dispatch"]["chunk_id"] == 3
+
+    def test_stats_json_reports_no_folds_for_empty_dispatch_table(
+        self, runner: CliRunner, project_dir: Path,
+    ) -> None:
+        init_result = runner.invoke(cli, ["init", "--project-root", str(project_dir)])
+        assert init_result.exit_code == 0
+
+        result = runner.invoke(cli, ["stats", "--project-root", str(project_dir), "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["last_fold_at"] is None
+        assert payload["last_fold_age_hours"] is None
+        assert payload["folds_last_7d"] == 0
+        assert payload["folds_last_30d"] == 0
+        assert payload["active_concepts"] == 0
+        assert payload["dead_concepts"] == 0
+        assert payload["buffer_fill_pct"] == 0.0
+        assert payload["buffer_items"] == 0
 
 
 class TestMigrateEpistemicHistory:


### PR DESCRIPTION
## Summary
- add `engram stats --json` with fold telemetry from committed dispatches, buffer state, and concept-registry counts
- add `--json` output to `engram status` for machine-readable status exports
- cover Part G with telemetry tests for recent folds and the empty-dispatch case

## Spec Reference
- https://github.com/rajeshgoli/office-automation/blob/main/docs/working/productivity_phase2.md#part-g-engram-fold-telemetry-engram-repo

## Test Plan
- [x] `source venv/bin/activate && python -m pytest tests/ -v`

Fixes rajeshgoli/engram#95